### PR TITLE
Oppgraderer Distroless til nodejs24-debian12@sha256:61f4f434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12@sha256:aad62f814208ec57ff3a67a9ca8764b0bfa0f7af9809008a04aada96f6987dab
+FROM gcr.io/distroless/nodejs24-debian12@sha256:61f4f4341db81820c24ce771b83d202eb6452076f58628cd536cc7d94a10978b
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Fra flex-cli