### PR TITLE
Oppgraderer Distroless til nodejs24-debian13@sha256:482fabdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12@sha256:61f4f4341db81820c24ce771b83d202eb6452076f58628cd536cc7d94a10978b
+FROM gcr.io/distroless/nodejs24-debian13@sha256:482fabdb0f0353417ab878532bb3bf45df925e3741c285a68038fb138b714cba
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Fra flex-cli