### PR TITLE
Fiks React-nøkkel for klippede søknader

### DIFF
--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -58,7 +58,7 @@ export const lagSoknadRader = ({
                                     start={dayjsToDate(k.fom)!}
                                     end={dayjsToDate(k.tom)!}
                                     status="neutral"
-                                    key={k.tom}
+                                    key={k.id}
                                     isActive={erAktiv}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
@@ -131,7 +131,7 @@ export const lagSoknadRader = ({
                                     start={dayjsToDate(k.fom)!}
                                     end={dayjsToDate(k.tom)!}
                                     status="neutral"
-                                    key={k.tom}
+                                    key={k.id}
                                     isActive={erAktiv}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {


### PR DESCRIPTION
## Problem
Klippede søknader med lik `tom`-dato fikk kolliderende React-nøkler, og bare én ble vist.

## Løsning
Bytter `key={k.tom}` → `key={k.id}` på alle `Timeline.Period`-elementer for klippede søknader. `KlippetSykepengesoknadRecord` har alltid et unikt `id`-felt.

## Endringer
- `SoknadRader.tsx`: 2 linjers endring (klippingAvSoknad + klippingAvSykmelding)