### PR TITLE
Tidslinje viser perioder utover dagens dato

### DIFF
--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -43,7 +43,11 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         <div className="min-w-[800px] min-h-[2000px] overflow-x-auto">
             <ValgteFilter filter={filter} setFilter={setFilter} />
             <BodyShort className="font-semibold">{`${sykmeldingAntall} sykmelding(er) · ${soknadAntall} søknad(er)`}</BodyShort>
-            <VelgZoomPeriode setFraDato={setVisningsFraDato} setTilDato={setVisningstilDato} maxTilDato={nysteTil ?? undefined} />
+            <VelgZoomPeriode
+                setFraDato={setVisningsFraDato}
+                setTilDato={setVisningstilDato}
+                maxTilDato={nysteTil ?? undefined}
+            />
             {aktivTidsvindu && (
                 <>
                     <SykmeldingTidslinje

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -31,6 +31,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         sykmeldingerGruppertPaArbeidsgiver,
         soknaderGruppert,
         aktivTidsvindu,
+        nysteTil,
         sykmeldingAntall,
         soknadAntall,
         handlePeriodeValgt,
@@ -42,7 +43,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         <div className="min-w-[800px] min-h-[2000px] overflow-x-auto">
             <ValgteFilter filter={filter} setFilter={setFilter} />
             <BodyShort className="font-semibold">{`${sykmeldingAntall} sykmelding(er) · ${soknadAntall} søknad(er)`}</BodyShort>
-            <VelgZoomPeriode setFraDato={setVisningsFraDato} setTilDato={setVisningstilDato} />
+            <VelgZoomPeriode setFraDato={setVisningsFraDato} setTilDato={setVisningstilDato} maxTilDato={nysteTil ?? undefined} />
             {aktivTidsvindu && (
                 <>
                     <SykmeldingTidslinje

--- a/src/components/VelgZoomPeriode.tsx
+++ b/src/components/VelgZoomPeriode.tsx
@@ -15,7 +15,7 @@ export default function VelgZoomPeriode({ setFraDato, setTilDato, maxTilDato }: 
         } else if (år) {
             setFraDato(dayjs().subtract(år, 'year').toDate())
         }
-        const tilDato = maxTilDato && dayjs() > dayjs(maxTilDato) ? maxTilDato : dayjs().toDate()
+        const tilDato = maxTilDato && dayjs(maxTilDato) > dayjs() ? maxTilDato : dayjs().toDate()
         setTilDato(tilDato)
     }
 

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -109,6 +109,7 @@ export const useTidslinjeKombinert = (
         sykmeldingerGruppertPaArbeidsgiver,
         soknaderGruppert,
         aktivTidsvindu,
+        nysteTil,
         sykmeldingAntall,
         soknadAntall,
         handlePeriodeValgt,


### PR DESCRIPTION
## Problem
Zoom-knappene (3 mnd, 7 mnd osv.) satte `tilDato` til dagens dato, selv om data strakk seg lenger frem i tid. Logikken i `VelgZoomPeriode` var invertert.

## Løsning
- Fiks sammenligningsretning: `dayjs(maxTilDato) > dayjs()` i stedet for `dayjs() > dayjs(maxTilDato)`
- Eksponerer `nysteTil` fra `useTidslinjeKombinert`
- Sender `nysteTil` som `maxTilDato` til `VelgZoomPeriode`

## Endringer
- `VelgZoomPeriode.tsx`: fiks logikk for tilDato
- `useTidslinjeKombinert.ts`: eksporter nysteTil
- `TidslinjeKombinert.tsx`: send maxTilDato til VelgZoomPeriode