### PR TITLE
Alltid vis detaljer med kortbasert styling

### DIFF
--- a/src/components/Detaljer.tsx
+++ b/src/components/Detaljer.tsx
@@ -42,7 +42,6 @@ const renderVerdi = (
     filter: Filter[],
     setFilter: React.Dispatch<React.SetStateAction<Filter[]>>,
     sti: string,
-    erRot = false,
 ): React.ReactNode => {
     if (erBladverdi(verdi)) {
         return <span>{formaterVerdi(verdi)}</span>
@@ -86,7 +85,7 @@ const renderVerdi = (
         if (nøkler.length === 0) return '{}'
 
         return (
-            <div className={erRot ? '' : 'ml-4'}>
+            <div className="ml-4">
                 {nøkler.map(([nøkkel, nestetVerdi]) => {
                     const nestetSti = sti ? `${sti}.${nøkkel}` : nøkkel
                     const bladverdi = erBladverdi(nestetVerdi)
@@ -123,6 +122,42 @@ const renderVerdi = (
     return <span>{formaterVerdi(verdi)}</span>
 }
 
+const renderRotnivå = (
+    objekt: object,
+    filter: Filter[],
+    setFilter: React.Dispatch<React.SetStateAction<Filter[]>>,
+): React.ReactNode => {
+    const nøkler = Object.entries(objekt)
+    return (
+        <div className="space-y-2">
+            {nøkler.map(([nøkkel, verdi]) => {
+                const sti = nøkkel
+                const bladverdi = erBladverdi(verdi)
+
+                return (
+                    <div key={nøkkel} className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                        <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">{nøkkel}</div>
+                        <div className="text-sm text-gray-900">
+                            {bladverdi ? (
+                                <FilterFelt
+                                    prop={sti}
+                                    verdi={verdi}
+                                    filter={filter}
+                                    setFilter={setFilter}
+                                    markerHeleRad
+                                    barn={<span>{formaterVerdi(verdi)}</span>}
+                                />
+                            ) : (
+                                renderVerdi(verdi, filter, setFilter, sti)
+                            )}
+                        </div>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
 export const Detaljer = ({
     objekt,
     filter,
@@ -131,4 +166,4 @@ export const Detaljer = ({
     objekt: object
     filter: Filter[]
     setFilter: React.Dispatch<React.SetStateAction<Filter[]>>
-}) => <Fragment>{renderVerdi(objekt, filter, setFilter, '', true)}</Fragment>
+}) => <Fragment>{renderRotnivå(objekt, filter, setFilter)}</Fragment>

--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -1,7 +1,7 @@
-import React, { useSyncExternalStore, useState } from 'react'
+import React, { useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import { Button, Heading } from '@navikt/ds-react'
-import { XMarkIcon, SidebarRightIcon, ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons'
+import { XMarkIcon, SidebarRightIcon } from '@navikt/aksel-icons'
 
 import { Detaljer } from './Detaljer'
 import { Filter } from './Filter'
@@ -64,32 +64,6 @@ export function lagKlippetSoknadDrawerInnhold(klippetSoknad: object): DrawerInnh
     }
 }
 
-function DetaljerMedToggle({
-    objekt,
-    filter,
-    setFilter,
-}: {
-    objekt: object
-    filter: Filter[]
-    setFilter: React.Dispatch<React.SetStateAction<Filter[]>>
-}) {
-    const [visDetaljer, setVisDetaljer] = useState(false)
-
-    return (
-        <div className="space-y-4">
-            <Button
-                variant="tertiary"
-                size="small"
-                onClick={() => setVisDetaljer(!visDetaljer)}
-                icon={visDetaljer ? <ChevronUpIcon aria-hidden /> : <ChevronDownIcon aria-hidden />}
-            >
-                {visDetaljer ? 'Skjul' : 'Vis'} fullstendige detaljer
-            </Button>
-            {visDetaljer && <Detaljer objekt={objekt} filter={filter} setFilter={setFilter} />}
-        </div>
-    )
-}
-
 function DrawerInnholdRenderer({
     variant,
     filter,
@@ -109,7 +83,7 @@ function DrawerInnholdRenderer({
                     <div className="flex h-full gap-6">
                         <div className="w-1/2 overflow-y-auto">{variant.periodeInfo}</div>
                         <div className="w-1/2 overflow-y-auto">
-                            <DetaljerMedToggle objekt={variant.objekt} filter={filter} setFilter={setFilter} />
+                            <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
                         </div>
                     </div>
                 )
@@ -117,7 +91,7 @@ function DrawerInnholdRenderer({
             return (
                 <div className="space-y-4">
                     {variant.periodeInfo}
-                    <DetaljerMedToggle objekt={variant.objekt} filter={filter} setFilter={setFilter} />
+                    <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
                 </div>
             )
         case 'klippetSoknad':

--- a/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
@@ -21,21 +21,37 @@ describe('ViktigePeriodefelt', () => {
             expect(screen.getByText('2024-01-31')).toBeInTheDocument()
         })
 
+        it('hvert felt rendres i en egen boks (kortbasert layout)', () => {
+            const { container } = render(
+                <ViktigePeriodefelt
+                    viktigeFelt={[
+                        { etikett: 'Fra', verdi: '2024-01-01' },
+                        { etikett: 'Til', verdi: '2024-01-31' },
+                    ]}
+                />,
+            )
+            const kortbokser = container.querySelectorAll('.rounded-lg.border')
+            expect(kortbokser).toHaveLength(2)
+        })
+
         it('viser CopyButton for felt som slutter på " id"', () => {
             const { container } = render(
                 <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Sykmelding ID', verdi: 'abc-123' }]} />,
             )
-            // CopyButton rendres som en button
             expect(container.querySelectorAll('button').length).toBeGreaterThan(0)
         })
 
         it('viser CopyButton for felt som starter med "ID"', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'ID', verdi: 'uuid-456' }]} />)
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'ID', verdi: 'uuid-456' }]} />,
+            )
             expect(container.querySelectorAll('button').length).toBeGreaterThan(0)
         })
 
         it('viser ikke CopyButton for vanlige felt', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
+            )
             expect(container.querySelectorAll('button')).toHaveLength(0)
         })
 
@@ -47,34 +63,51 @@ describe('ViktigePeriodefelt', () => {
 
     describe('statusfarger', () => {
         it('viser advarselsfarge for AVBRUTT-status', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'AVBRUTT' }]} />)
-            const statusElement = container.querySelector('.bg-ax-bg-warning-moderate')
-            expect(statusElement).toBeInTheDocument()
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'AVBRUTT' }]} />,
+            )
+            expect(container.querySelector('.bg-ax-bg-warning-moderate')).toBeInTheDocument()
         })
 
         it('viser suksessfarge for SENDT-status', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
-            const statusElement = container.querySelector('.bg-ax-bg-success-moderate')
-            expect(statusElement).toBeInTheDocument()
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
+            )
+            expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
         })
 
         it('viser infofarge for ukjent status', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'NY' }]} />)
-            const statusElement = container.querySelector('.bg-ax-bg-info-moderate')
-            expect(statusElement).toBeInTheDocument()
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'NY' }]} />,
+            )
+            expect(container.querySelector('.bg-ax-bg-info-moderate')).toBeInTheDocument()
         })
 
         it('statussammenligning er case-insensitiv', () => {
-            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'sendt' }]} />)
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'sendt' }]} />,
+            )
             expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
+        })
+
+        it('statusfelt har border-transparent i stedet for vanlig grå border', () => {
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
+            )
+            expect(container.querySelector('.border-transparent')).toBeInTheDocument()
+        })
+
+        it('vanlig felt har border-gray-200', () => {
+            const { container } = render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} />,
+            )
+            expect(container.querySelector('.border-gray-200')).toBeInTheDocument()
         })
     })
 
     describe('delperiodeTekster', () => {
         it('viser ikke periodeliste ved 0 tekster', () => {
-            render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} delperiodeTekster={[]} />,
-            )
+            render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} delperiodeTekster={[]} />)
             expect(screen.queryByText('Perioder')).not.toBeInTheDocument()
         })
 
@@ -98,6 +131,17 @@ describe('ViktigePeriodefelt', () => {
             expect(screen.getByText('Perioder')).toBeInTheDocument()
             expect(screen.getByText('01.01 – 15.01')).toBeInTheDocument()
             expect(screen.getByText('16.01 – 31.01')).toBeInTheDocument()
+        })
+
+        it('periodeblokken er en egen kortboks i tillegg til feltene', () => {
+            const { container } = render(
+                <ViktigePeriodefelt
+                    viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]}
+                    delperiodeTekster={['01.01 – 15.01', '16.01 – 31.01']}
+                />,
+            )
+            // 1 felt + 1 periodeblokk = 2 kortbokser
+            expect(container.querySelectorAll('.rounded-lg.border')).toHaveLength(2)
         })
     })
 })

--- a/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
@@ -21,7 +21,7 @@ describe('ViktigePeriodefelt', () => {
             expect(screen.getByText('2024-01-31')).toBeInTheDocument()
         })
 
-        it('hvert felt rendres i en egen boks (kortbasert layout)', () => {
+        it('alle felt rendres inni én felles kortboks', () => {
             const { container } = render(
                 <ViktigePeriodefelt
                     viktigeFelt={[
@@ -31,7 +31,7 @@ describe('ViktigePeriodefelt', () => {
                 />,
             )
             const kortbokser = container.querySelectorAll('.rounded-lg.border')
-            expect(kortbokser).toHaveLength(2)
+            expect(kortbokser).toHaveLength(1)
         })
 
         it('viser CopyButton for felt som slutter på " id"', () => {
@@ -78,14 +78,15 @@ describe('ViktigePeriodefelt', () => {
             expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
         })
 
-        it('statusfelt har border-transparent i stedet for vanlig grå border', () => {
+        it('statusfelt får fargeklasse', () => {
             const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
-            expect(container.querySelector('.border-transparent')).toBeInTheDocument()
+            expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
         })
 
-        it('vanlig felt har border-gray-200', () => {
+        it('vanlig felt har ikke statusfarge', () => {
             const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} />)
-            expect(container.querySelector('.border-gray-200')).toBeInTheDocument()
+            expect(container.querySelector('.bg-ax-bg-success-moderate')).not.toBeInTheDocument()
+            expect(container.querySelector('.bg-ax-bg-warning-moderate')).not.toBeInTheDocument()
         })
     })
 
@@ -119,14 +120,14 @@ describe('ViktigePeriodefelt', () => {
             expect(screen.getByText('16.01 – 31.01')).toBeInTheDocument()
         })
 
-        it('periodeblokken er en egen kortboks i tillegg til feltene', () => {
+        it('periodeblokken er en egen kortboks ved siden av felt-kortet', () => {
             const { container } = render(
                 <ViktigePeriodefelt
                     viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]}
                     delperiodeTekster={['01.01 – 15.01', '16.01 – 31.01']}
                 />,
             )
-            // 1 felt + 1 periodeblokk = 2 kortbokser
+            // 1 felt-kort + 1 periodeblokk = 2 kortbokser
             expect(container.querySelectorAll('.rounded-lg.border')).toHaveLength(2)
         })
     })

--- a/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.test.tsx
@@ -42,16 +42,12 @@ describe('ViktigePeriodefelt', () => {
         })
 
         it('viser CopyButton for felt som starter med "ID"', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'ID', verdi: 'uuid-456' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'ID', verdi: 'uuid-456' }]} />)
             expect(container.querySelectorAll('button').length).toBeGreaterThan(0)
         })
 
         it('viser ikke CopyButton for vanlige felt', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
             expect(container.querySelectorAll('button')).toHaveLength(0)
         })
 
@@ -63,51 +59,41 @@ describe('ViktigePeriodefelt', () => {
 
     describe('statusfarger', () => {
         it('viser advarselsfarge for AVBRUTT-status', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'AVBRUTT' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'AVBRUTT' }]} />)
             expect(container.querySelector('.bg-ax-bg-warning-moderate')).toBeInTheDocument()
         })
 
         it('viser suksessfarge for SENDT-status', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
             expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
         })
 
         it('viser infofarge for ukjent status', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'NY' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'NY' }]} />)
             expect(container.querySelector('.bg-ax-bg-info-moderate')).toBeInTheDocument()
         })
 
         it('statussammenligning er case-insensitiv', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'sendt' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'sendt' }]} />)
             expect(container.querySelector('.bg-ax-bg-success-moderate')).toBeInTheDocument()
         })
 
         it('statusfelt har border-transparent i stedet for vanlig grå border', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Status', verdi: 'SENDT' }]} />)
             expect(container.querySelector('.border-transparent')).toBeInTheDocument()
         })
 
         it('vanlig felt har border-gray-200', () => {
-            const { container } = render(
-                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} />,
-            )
+            const { container } = render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} />)
             expect(container.querySelector('.border-gray-200')).toBeInTheDocument()
         })
     })
 
     describe('delperiodeTekster', () => {
         it('viser ikke periodeliste ved 0 tekster', () => {
-            render(<ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} delperiodeTekster={[]} />)
+            render(
+                <ViktigePeriodefelt viktigeFelt={[{ etikett: 'Fra', verdi: '2024-01-01' }]} delperiodeTekster={[]} />,
+            )
             expect(screen.queryByText('Perioder')).not.toBeInTheDocument()
         })
 

--- a/src/components/periodeinfo/ViktigePeriodefelt.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.tsx
@@ -79,7 +79,9 @@ export default function ViktigePeriodefelt({ viktigeFelt, delperiodeTekster = []
                 >
                     <span className="mt-0.5 flex shrink-0 items-center text-gray-600">{hentIkon(felt.etikett)}</span>
                     <div className="flex flex-col gap-0.5">
-                        <span className="text-xs font-medium uppercase tracking-wide text-gray-500">{felt.etikett}</span>
+                        <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                            {felt.etikett}
+                        </span>
                         <span className="flex items-center gap-1 font-medium text-gray-900">
                             {felt.verdi}
                             {(felt.etikett.toLowerCase().endsWith(' id') ||

--- a/src/components/periodeinfo/ViktigePeriodefelt.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.tsx
@@ -67,48 +67,44 @@ const hentFargeFraStatus = (status: string): string => {
 
 export default function ViktigePeriodefelt({ viktigeFelt, delperiodeTekster = [] }: Props) {
     return (
-        <div className="space-y-3">
-            <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
-                <ul className="space-y-2">
-                    {viktigeFelt.map((felt) => (
-                        <li
-                            key={felt.etikett}
-                            className={`flex items-start gap-3 text-sm p-2 ${felt.etikett == 'Status' ? hentFargeFraStatus(felt.verdi as string) + ' rounded-2xl' : ''}`}
-                        >
-                            <span className="flex shrink-0 items-center text-gray-700">{hentIkon(felt.etikett)}</span>
-                            <div className="flex flex-col">
-                                <span className="font-medium text-gray-700 ">{felt.etikett}</span>
-                                <span className="flex items-center gap-1 text-gray-900">
-                                    {felt.verdi}
-                                    {(felt.etikett.toLowerCase().endsWith(' id') ||
-                                        felt.etikett.toLowerCase().startsWith('id')) && (
-                                        <CopyButton size="xsmall" copyText={String(felt.verdi)} />
-                                    )}
-                                </span>
-                            </div>
-                        </li>
-                    ))}
-                </ul>
-            </div>
+        <div className="space-y-2">
+            {viktigeFelt.map((felt) => (
+                <div
+                    key={felt.etikett}
+                    className={`flex items-start gap-3 rounded-lg border p-3 text-sm shadow-sm ${
+                        felt.etikett === 'Status'
+                            ? hentFargeFraStatus(felt.verdi as string) + ' border-transparent'
+                            : 'border-gray-200 bg-white'
+                    }`}
+                >
+                    <span className="mt-0.5 flex shrink-0 items-center text-gray-600">{hentIkon(felt.etikett)}</span>
+                    <div className="flex flex-col gap-0.5">
+                        <span className="text-xs font-medium uppercase tracking-wide text-gray-500">{felt.etikett}</span>
+                        <span className="flex items-center gap-1 font-medium text-gray-900">
+                            {felt.verdi}
+                            {(felt.etikett.toLowerCase().endsWith(' id') ||
+                                felt.etikett.toLowerCase().startsWith('id')) && (
+                                <CopyButton size="xsmall" copyText={String(felt.verdi)} />
+                            )}
+                        </span>
+                    </div>
+                </div>
+            ))}
 
             {delperiodeTekster.length > 1 && (
-                <>
-                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
-                        <ul className="space-y-2">
-                            <li className="flex items-center gap-2 font-semibold text-gray-700">
-                                <span className="flex items-center text-gray-700">
-                                    <FilesIcon aria-hidden fontSize="1.25rem" />
-                                </span>
-                                Perioder
-                            </li>
-                            {delperiodeTekster.map((tekst, indeks) => (
-                                <li key={`${tekst}-${indeks}`} className="ml-6 text-sm text-gray-900">
-                                    {tekst}
-                                </li>
-                            ))}
-                        </ul>
+                <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
+                    <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+                        <FilesIcon aria-hidden fontSize="1.25rem" />
+                        Perioder
                     </div>
-                </>
+                    <ul className="space-y-1">
+                        {delperiodeTekster.map((tekst, indeks) => (
+                            <li key={`${tekst}-${indeks}`} className="text-sm text-gray-900">
+                                {tekst}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
             )}
         </div>
     )

--- a/src/components/periodeinfo/ViktigePeriodefelt.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.tsx
@@ -68,30 +68,34 @@ const hentFargeFraStatus = (status: string): string => {
 export default function ViktigePeriodefelt({ viktigeFelt, delperiodeTekster = [] }: Props) {
     return (
         <div className="space-y-2">
-            {viktigeFelt.map((felt) => (
-                <div
-                    key={felt.etikett}
-                    className={`flex items-start gap-3 rounded-lg border p-3 text-sm shadow-sm ${
-                        felt.etikett === 'Status'
-                            ? hentFargeFraStatus(felt.verdi as string) + ' border-transparent'
-                            : 'border-gray-200 bg-white'
-                    }`}
-                >
-                    <span className="mt-0.5 flex shrink-0 items-center text-gray-600">{hentIkon(felt.etikett)}</span>
-                    <div className="flex flex-col gap-0.5">
-                        <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                            {felt.etikett}
+            <ul className="space-y-2">
+                {viktigeFelt.map((felt) => (
+                    <li
+                        key={felt.etikett}
+                        className={`flex items-start gap-3 rounded-lg border p-3 text-sm shadow-sm ${
+                            felt.etikett === 'Status'
+                                ? `${hentFargeFraStatus(felt.verdi as string)} border-transparent`
+                                : 'border-gray-200 bg-white'
+                        }`}
+                    >
+                        <span className="mt-0.5 flex shrink-0 items-center text-gray-600">
+                            {hentIkon(felt.etikett)}
                         </span>
-                        <span className="flex items-center gap-1 font-medium text-gray-900">
-                            {felt.verdi}
-                            {(felt.etikett.toLowerCase().endsWith(' id') ||
-                                felt.etikett.toLowerCase().startsWith('id')) && (
-                                <CopyButton size="xsmall" copyText={String(felt.verdi)} />
-                            )}
-                        </span>
-                    </div>
-                </div>
-            ))}
+                        <div className="flex flex-col gap-0.5">
+                            <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                                {felt.etikett}
+                            </span>
+                            <span className="flex items-center gap-1 font-medium text-gray-900">
+                                {felt.verdi}
+                                {(felt.etikett.toLowerCase().endsWith(' id') ||
+                                    felt.etikett.toLowerCase().startsWith('id')) && (
+                                    <CopyButton size="xsmall" copyText={String(felt.verdi)} />
+                                )}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
 
             {delperiodeTekster.length > 1 && (
                 <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">

--- a/src/components/periodeinfo/ViktigePeriodefelt.tsx
+++ b/src/components/periodeinfo/ViktigePeriodefelt.tsx
@@ -67,45 +67,41 @@ const hentFargeFraStatus = (status: string): string => {
 
 export default function ViktigePeriodefelt({ viktigeFelt, delperiodeTekster = [] }: Props) {
     return (
-        <div className="space-y-2">
-            <ul className="space-y-2">
-                {viktigeFelt.map((felt) => (
-                    <li
-                        key={felt.etikett}
-                        className={`flex items-start gap-3 rounded-lg border p-3 text-sm shadow-sm ${
-                            felt.etikett === 'Status'
-                                ? `${hentFargeFraStatus(felt.verdi as string)} border-transparent`
-                                : 'border-gray-200 bg-white'
-                        }`}
-                    >
-                        <span className="mt-0.5 flex shrink-0 items-center text-gray-600">
-                            {hentIkon(felt.etikett)}
-                        </span>
-                        <div className="flex flex-col gap-0.5">
-                            <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                                {felt.etikett}
-                            </span>
-                            <span className="flex items-center gap-1 font-medium text-gray-900">
-                                {felt.verdi}
-                                {(felt.etikett.toLowerCase().endsWith(' id') ||
-                                    felt.etikett.toLowerCase().startsWith('id')) && (
-                                    <CopyButton size="xsmall" copyText={String(felt.verdi)} />
-                                )}
-                            </span>
-                        </div>
-                    </li>
-                ))}
-            </ul>
+        <div className="space-y-3">
+            <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
+                <ul className="space-y-2">
+                    {viktigeFelt.map((felt) => (
+                        <li
+                            key={felt.etikett}
+                            className={`flex items-start gap-3 p-2 text-sm ${felt.etikett === 'Status' ? `${hentFargeFraStatus(felt.verdi as string)} rounded-2xl` : ''}`}
+                        >
+                            <span className="flex shrink-0 items-center text-gray-700">{hentIkon(felt.etikett)}</span>
+                            <div className="flex flex-col">
+                                <span className="font-medium text-gray-700">{felt.etikett}</span>
+                                <span className="flex items-center gap-1 text-gray-900">
+                                    {felt.verdi}
+                                    {(felt.etikett.toLowerCase().endsWith(' id') ||
+                                        felt.etikett.toLowerCase().startsWith('id')) && (
+                                        <CopyButton size="xsmall" copyText={String(felt.verdi)} />
+                                    )}
+                                </span>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
 
             {delperiodeTekster.length > 1 && (
-                <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm">
-                    <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500">
-                        <FilesIcon aria-hidden fontSize="1.25rem" />
-                        Perioder
-                    </div>
-                    <ul className="space-y-1">
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                    <ul className="space-y-2">
+                        <li className="flex items-center gap-2 font-semibold text-gray-700">
+                            <span className="flex items-center text-gray-700">
+                                <FilesIcon aria-hidden fontSize="1.25rem" />
+                            </span>
+                            Perioder
+                        </li>
                         {delperiodeTekster.map((tekst, indeks) => (
-                            <li key={`${tekst}-${indeks}`} className="text-sm text-gray-900">
+                            <li key={`${tekst}-${indeks}`} className="ml-6 text-sm text-gray-900">
                                 {tekst}
                             </li>
                         ))}


### PR DESCRIPTION


Fjerner toggle for detaljer — informasjonen vises alltid. Hvert felt får sin egen kortboks med ikon, etikett og verdi.
