### PR TITLE
Rød border på valgt periode i kombinert tidslinje

### DIFF
--- a/src/components/kombinert/PeriodeMarkering.test.tsx
+++ b/src/components/kombinert/PeriodeMarkering.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import dayjs from 'dayjs'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Soknad } from '../../queryhooks/useSoknader'
+import { mapTilSykmelding } from '../../queryhooks/useSykmeldinger'
+import { sykmeldingerTestdata } from '../../testdata/sykmeldingerTestdata'
+import { ArbeidsgiverGruppering } from '../../utils/gruppering'
+import { SykmeldingerPerArbeidsgiver } from '../sykmelding/sykmeldingTidslinjeUtils'
+
+import { lagSoknadRader } from './SoknadRader'
+import { lagSykmeldingRader } from './SykmeldingRader'
+
+const aktivTidsvindu = {
+    fra: new Date(Date.UTC(2026, 0, 1)),
+    til: new Date(Date.UTC(2026, 11, 31)),
+}
+
+const onPeriodeValgt = vi.fn()
+
+interface PeriodProps {
+    className?: string
+    children?: React.ReactNode
+}
+
+const hentForstePeriodeFraRader = (rader: React.ReactElement[]) => {
+    const forsteRad = rader[0] as React.ReactElement<PeriodProps>
+    const perioder = React.Children.toArray(forsteRad.props.children) as React.ReactElement<PeriodProps>[]
+    return perioder[0]
+}
+
+describe('PeriodeMarkering', () => {
+    it('markerer valgt sykmeldingsperiode med tydelig rød shadow-klasse', () => {
+        const sykmelding = mapTilSykmelding(sykmeldingerTestdata[0])
+        const sykmeldingerGruppertPaArbeidsgiver = new Map<string, SykmeldingerPerArbeidsgiver>([
+            [
+                'arbeidsgiver-1',
+                {
+                    label: 'Arbeidsgiver',
+                    sykmeldinger: [sykmelding],
+                    dagNokler: new Set<string>(),
+                },
+            ],
+        ])
+
+        const rader = lagSykmeldingRader({
+            sykmeldingerGruppertPaArbeidsgiver,
+            aktivTidsvindu,
+            aktivPeriodeId: sykmelding.id,
+            aktivDrawerKildeId: sykmelding.id,
+            onPeriodeValgt,
+        })
+
+        const periode = hentForstePeriodeFraRader(rader)
+        expect(periode.props.className).toContain('shadow-[inset_0_0_0_4px_#dc2626]!')
+    })
+
+    it('markerer valgt søknadsperiode med tydelig rød shadow-klasse', () => {
+        const soknad = new Soknad({
+            id: 'soknad-1',
+            sykmeldingId: 'sykmelding-1',
+            soknadstype: 'ARBEIDSTAKERE',
+            status: 'SENDT',
+            arbeidssituasjon: 'ARBEIDSTAKER',
+            arbeidsgiverOrgnummer: '123456789',
+            arbeidsgiverNavn: 'Arbeidsgiver',
+            fom: '2026-03-01',
+            tom: '2026-03-15',
+            sykmeldingSignaturDato: '2026-02-28',
+            opprettetDato: '2026-03-16T10:00:00',
+            soknadPerioder: [],
+        })
+
+        const soknaderGruppert = new Map<string, ArbeidsgiverGruppering>([
+            [
+                '123456789',
+                {
+                    sykmeldinger: new Map([
+                        [
+                            'sykmelding-1',
+                            {
+                                soknader: new Map([
+                                    [
+                                        soknad.id,
+                                        {
+                                            soknad,
+                                            klippingAvSoknad: [],
+                                        },
+                                    ],
+                                ]),
+                                klippingAvSykmelding: [],
+                            },
+                        ],
+                    ]),
+                },
+            ],
+        ])
+
+        const rader = lagSoknadRader({
+            soknaderGruppert,
+            aktivTidsvindu,
+            aktivPeriodeId: 'sykmelding-1',
+            aktivDrawerKildeId: soknad.id,
+            onPeriodeValgt,
+        })
+
+        const periode = hentForstePeriodeFraRader(rader)
+        expect(periode.props.className).toContain('shadow-[inset_0_0_0_4px_#dc2626]!')
+    })
+
+    it('beholder standard sykmelding-border når perioden ikke er valgt', () => {
+        const sykmelding = mapTilSykmelding(sykmeldingerTestdata[1])
+        const sykmeldingerGruppertPaArbeidsgiver = new Map<string, SykmeldingerPerArbeidsgiver>([
+            [
+                'arbeidsgiver-1',
+                {
+                    label: 'Arbeidsgiver',
+                    sykmeldinger: [{ ...sykmelding, signaturDato: dayjs('2026-01-28') }],
+                    dagNokler: new Set<string>(),
+                },
+            ],
+        ])
+
+        const rader = lagSykmeldingRader({
+            sykmeldingerGruppertPaArbeidsgiver,
+            aktivTidsvindu,
+            aktivPeriodeId: null,
+            aktivDrawerKildeId: null,
+            onPeriodeValgt,
+        })
+
+        const periode = hentForstePeriodeFraRader(rader)
+        expect(periode.props.className).toContain('ring-1 ring-inset ring-white/95')
+    })
+})

--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -63,7 +63,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -95,7 +95,7 @@ export const lagSoknadRader = ({
                                     icon={ikonerForSoknad(sok.soknad)}
                                     key={sok.soknad.tom?.toISOString() ?? sok.soknad.id}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -143,7 +143,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)

--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -53,6 +53,7 @@ export const lagSoknadRader = ({
                             const sykmeldingId = k.sykmeldingUuid ?? null
                             const erAktiv = aktivPeriodeId !== null && aktivPeriodeId === sykmeldingId
                             const kildeId = k.id
+                            const erValgtPeriode = aktivDrawerKildeId === kildeId
 
                             return (
                                 <Timeline.Period
@@ -62,6 +63,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
+                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -84,6 +86,7 @@ export const lagSoknadRader = ({
                             const sykmeldingId = sok.soknad.sykmeldingId ?? null
                             const erAktiv = aktivPeriodeId !== null && aktivPeriodeId === sykmeldingId
                             const kildeId = sok.soknad.id
+                            const erValgtPeriode = aktivDrawerKildeId === kildeId
                             klippingAvSoknad.push(
                                 <Timeline.Period
                                     start={sokFom}
@@ -92,6 +95,7 @@ export const lagSoknadRader = ({
                                     icon={ikonerForSoknad(sok.soknad)}
                                     key={sok.soknad.tom?.toISOString() ?? sok.soknad.id}
                                     isActive={erAktiv}
+                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -129,6 +133,7 @@ export const lagSoknadRader = ({
                             const sykmeldingId = k.sykmeldingUuid ?? null
                             const erAktiv = aktivPeriodeId !== null && aktivPeriodeId === sykmeldingId
                             const kildeId = k.id
+                            const erValgtPeriode = aktivDrawerKildeId === kildeId
 
                             return (
                                 <Timeline.Period
@@ -138,6 +143,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
+                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)

--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -63,7 +63,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -95,7 +95,7 @@ export const lagSoknadRader = ({
                                     icon={ikonerForSoknad(sok.soknad)}
                                     key={sok.soknad.tom?.toISOString() ?? sok.soknad.id}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
@@ -143,7 +143,7 @@ export const lagSoknadRader = ({
                                     key={k.id}
                                     icon={klippIkon}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'ring-2 ring-red-600' : undefined}
+                                    className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : undefined}
                                     onSelectPeriod={() => {
                                         if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -74,7 +74,7 @@ export const lagSykmeldingRader = ({
                         end={sistePeriode.sluttDato}
                         status={status}
                         icon={ikon}
-                        className={erValgtPeriode ? 'ring-2 ring-red-600' : 'ring-1 ring-inset ring-white/95'}
+                        className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : 'ring-1 ring-inset ring-white/95'}
                         key={periodeKey}
                         isActive={aktivPeriodeId === sykmeldingAktivId}
                         onSelectPeriod={() => {

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -66,13 +66,15 @@ export const lagSykmeldingRader = ({
                 const sykmeldingAktivId = sykmelding.id
                 const ikonHeader = ikonParForSykmeldingPerioder(perioder.length, forstePeriodetype, arbeidssituasjon)
 
+                const erValgtPeriode = aktivDrawerKildeId === sykmeldingAktivId
+
                 return [
                     <Timeline.Period
                         start={forstePeriode.startDato}
                         end={sistePeriode.sluttDato}
                         status={status}
                         icon={ikon}
-                        className="ring-1 ring-inset ring-white/95"
+                        className={erValgtPeriode ? 'ring-2 ring-red-600' : 'ring-1 ring-inset ring-white/95'}
                         key={periodeKey}
                         isActive={aktivPeriodeId === sykmeldingAktivId}
                         onSelectPeriod={() => {

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -4,11 +4,7 @@ import { Timeline } from '@navikt/ds-react'
 
 import { erPeriodeInnenforTidsvindu } from '../../utils/tidslinjeUtils'
 import { sorterSykmeldingGrupperEtterSignaturDato } from '../../utils/kombinertTidslinjeSortering'
-import {
-    ikonForSykmeldingPerioder,
-    ikonParForSykmeldingPerioder,
-    beskrivelseForSykmeldingPerioder,
-} from '../../utils/tidslinjeIkonUtils'
+import { ikonForSykmeldingPerioder, ikonParForSykmeldingPerioder } from '../../utils/tidslinjeIkonUtils'
 import type { DrawerInnhold } from '../DetaljerDrawer'
 import { lagSykmeldingDrawerInnhold } from '../DetaljerDrawer'
 import ViktigeFeltForSykmelding from '../periodeinfo/ViktigeFeltForSykmelding'
@@ -74,7 +70,9 @@ export const lagSykmeldingRader = ({
                         end={sistePeriode.sluttDato}
                         status={status}
                         icon={ikon}
-                        className={erValgtPeriode ? 'ring-4 ring-inset ring-red-600' : 'ring-1 ring-inset ring-white/95'}
+                        className={
+                            erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : 'ring-1 ring-inset ring-white/95'
+                        }
                         key={periodeKey}
                         isActive={aktivPeriodeId === sykmeldingAktivId}
                         onSelectPeriod={() => {


### PR DESCRIPTION
Gjør det tydeligere hvilken spesifikk periode som er valgt på tidslinjen ved å legge på rød border 

Relaterte perioder (samme sykmelding) markeres fortsatt som aktive via `isActive`, men nå er det lett å se akkurat hvilken periode som ble klikket.