### PR TITLE
Oppgraderer Distroless til nodejs24-debian13@sha256:e70510b4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian13@sha256:482fabdb0f0353417ab878532bb3bf45df925e3741c285a68038fb138b714cba
+FROM gcr.io/distroless/nodejs24-debian13@sha256:e70510b44870c5686983f2b11f22b884f2dfacf86aea69b6b0edb2ccb3f237f4
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Fra flex-cli