### PR TITLE
Fiks krasj ved andre søk i tidslinjeKombinert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ pnpm run format           # Prettier + ESLint fixes
 pnpm run prettier:check   # Check formatting
 ```
 
-**Note:** Tests use Vitest (ESM-compatible alternative to Jest). Test file convention: `.test.ts` suffix. Example: `/src/utils/sykmeldingValidering.test.ts`.
+**Note:** Tests use Vitest (ESM-compatible alternative to Jest). Test file convention: `.test.ts` / `.test.tsx` suffix. Example: `/src/utils/sykmeldingValidering.test.ts`.
 
 **Before every commit:** always run `pnpm run format && pnpm run build` to fix formatting and verify the build compiles. Remove unused imports and dead code before committing.
 
@@ -150,6 +150,15 @@ pnpm run prettier:check   # Check formatting
 - Timeline components receive `soknader` (applications) and `klipp` (clipped/overlapping records) as arrays
 - Parent components handle filtering and grouping; pass filtered data to children
 - Query hooks centralize all backend communication
+- **`ValgtFnrProvider`** (`/src/utils/useValgtFnr.ts`) holds global search state (fnr, selected period, lookup data). Functions exposed via context (`settValgtPeriode`, `nullstillValgtPeriode`) must be wrapped in `useCallback` to avoid infinite render loops when used in `useEffect` dependency arrays.
+
+### useCallback for stable references
+
+Always wrap handler functions in `useCallback` when they are:
+- Exposed from a context provider (e.g. `useValgtFnr`)
+- Returned from a custom hook and used in `useEffect` deps (e.g. `useTidslinjeKombinert`)
+
+Failing to do so causes the function reference to change on every render, which triggers effects repeatedly and can exceed React's max update depth limit.
 
 ## File Organization
 
@@ -188,7 +197,8 @@ pnpm run prettier:check   # Check formatting
 ### Modifying Timeline Data Flow
 
 - Update filter/grouping logic in `/src/utils/filterlogikk.ts` or `/src/utils/gruppering.ts`
-- Timeline component state in `/src/components/Tidslinje.tsx` recomputes on filter changes via `useEffect`
+- Timeline state lives in `useTidslinjeKombinert` (custom hook in `/src/components/kombinert/`)
+- `TidslinjeKombinert` recomputes on filter changes via `useEffect`
 
 ## Deployment & Environment
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,14 +55,13 @@ Pages are in `/src/pages/`, components in `/src/components/`:
 
 ```
 index.tsx (main page)
-  └─ Tidslinje (timeline component)
-    ├─ Filter (chip-based filtering by properties)
-    ├─ ValgtArbeidsgiver (employer selector dropdown)
-    ├─ TidslinjeArbeidsgiver (employer timeline)
-    └─ TidslinjeSykmelding (sickness certificate timeline)
+  └─ TidslinjeKombinert   (combined timeline — sykmeldinger + søknader)
+    ├─ Filter             (chip-based filtering by properties)
+    ├─ VelgZoomPeriode    (zoom window selector)
+    └─ DetaljerDrawer     (side panel with period details)
 ```
 
-Components use **local state** via `useState` for UI state (selected employer, active filters). Timeline components display data grouped and sorted by employer and date range.
+Components use **local state** via `useState` for UI state (active filters, drawer). Timeline state is centralised in `useTidslinjeKombinert` (`/src/components/kombinert/`).
 
 ### Environment & Mock Backend
 
@@ -126,7 +125,7 @@ pnpm run prettier:check   # Check formatting
 
 **Note:** Tests use Vitest (ESM-compatible alternative to Jest). Test file convention: `.test.ts` / `.test.tsx` suffix. Example: `/src/utils/sykmeldingValidering.test.ts`.
 
-**Before every commit:** always run `pnpm run format && pnpm run build` to fix formatting and verify the build compiles. Remove unused imports and dead code before committing.
+**Before every commit:** always run `pnpm run format && pnpm run test && pnpm run build`. This fixes formatting, verifies tests pass, and confirms the build compiles. Remove unused imports and dead code before committing.
 
 ## Styling
 
@@ -216,18 +215,35 @@ Failing to do so causes the function reference to change on every render, which 
 - [ ] Filters/grouping logic tested with edge cases (empty data, overlaps)
 - [ ] Mock data in testdata.ts matches real backend response shape
 - [ ] Environment checks (`isMockBackend()`, `isProd()`) properly used
-- [ ] Tailwind class names sorted (prettier plugin handles this)
+- [ ] `pnpm run format && pnpm run test && pnpm run build` passed before commit
 - [ ] No explicit return type annotations on short arrow functions (ESLint disables it)
 
-## Commit Message Style
+## Git Workflow
+
+**Every feature or fix gets its own branch.** Never commit directly to `main`.
+
+```sh
+git checkout -b kort-beskrivende-navn   # e.g. fiks-krasj-ved-andre-sok
+# ... make changes ...
+pnpm run format && pnpm run test && pnpm run build
+git commit -m "Kort beskrivelse på norsk"
+git push origin <branch>
+gh pr create --fill
+```
+
+### Commit Message Style
 
 Keep commit messages short and in Norwegian, matching the style of recent commits. Examples:
 
 ```
 Vis OPPHOLD_UTLAND-søknader som pin i tidslinjen
 Viser tydeligere viktige felter
-Vis meldingtilnavdager
+Fiks krasj ved nytt søk i kombinert tidslinje
 ```
+
+- One line, imperative or descriptive, no period at end
+- Norwegian Bokmål
+- No issue numbers required
 
 ## Contact
 

--- a/src/components/IdOppslagSokefelt.andreSok.test.tsx
+++ b/src/components/IdOppslagSokefelt.andreSok.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ValgtFnrProvider } from '../utils/useValgtFnr'
+
+import IdOppslagSokefelt from './IdOppslagSokefelt'
+
+const mockUseSoknad = vi.fn()
+const mockUseSykmelding = vi.fn()
+
+vi.mock('../queryhooks/useSoknad', () => ({
+    useSoknad: (...args: unknown[]) => mockUseSoknad(...args),
+}))
+
+vi.mock('../queryhooks/useSykmelding', () => ({
+    useSykmelding: (...args: unknown[]) => mockUseSykmelding(...args),
+}))
+
+const gyldigUuid1 = '11111111-1111-1111-1111-111111111111'
+const gyldigUuid2 = '22222222-2222-2222-2222-222222222222'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ValgtFnrProvider>{children}</ValgtFnrProvider>
+        </QueryClientProvider>
+    )
+}
+
+describe('IdOppslagSokefelt – andre søk etter første', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseSoknad.mockReturnValue({ data: null, isFetching: false })
+        mockUseSykmelding.mockReturnValue({ data: null, isFetching: false })
+    })
+
+    it('håndterer andre søk etter første søk uten å krasje', async () => {
+        const { rerender } = render(<IdOppslagSokefelt />, { wrapper: Wrapper })
+        const input = screen.getByLabelText('Søknad-ID eller sykmelding-ID')
+
+        // Første søk: søknad funnet
+        await userEvent.type(input, gyldigUuid1 + '{enter}')
+        mockUseSoknad.mockReturnValue({
+            data: { fnr: '12345678901', sykepengesoknad: { id: gyldigUuid1, sykmeldingId: null } },
+            isFetching: false,
+        })
+        rerender(<IdOppslagSokefelt />)
+
+        // Vent slik at setId(undefined)-timeren rekker å kjøre
+        await new Promise((r) => setTimeout(r, 10))
+
+        // Tilbakestill til ingen data (ny søk starter)
+        mockUseSoknad.mockReturnValue({ data: null, isFetching: false })
+        mockUseSykmelding.mockReturnValue({ data: null, isFetching: false })
+        rerender(<IdOppslagSokefelt />)
+
+        // Andre søk: sykmelding funnet
+        await userEvent.clear(input)
+        await userEvent.type(input, gyldigUuid2 + '{enter}')
+        mockUseSykmelding.mockReturnValue({
+            data: {
+                sykmelding: {
+                    id: gyldigUuid2,
+                    sykmeldingsperioder: [],
+                    pasient: { fnr: '98765432109', overSyttiAar: null },
+                },
+                fnr: '98765432109',
+            },
+            isFetching: false,
+        })
+        rerender(<IdOppslagSokefelt />)
+
+        // Ingen feilmelding — komponenten krasjet ikke
+        expect(screen.queryByText('Fant ikke fnr for oppgitt ID')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { KlippetSykepengesoknadRecord, Soknad, dayjsToDate } from '../../queryhooks/useSoknader'
 import type { Sykmelding } from '../../queryhooks/useSykmeldinger'
@@ -80,21 +80,24 @@ export const useTidslinjeKombinert = (
           ).length
         : filtrerteSoknaderAntall
 
-    const handlePeriodeValgt = (periodeId: string | null, kildeId: string | null, drawer: DrawerInnhold | null) => {
-        setAktivPeriodeId(periodeId)
+    const handlePeriodeValgt = useCallback(
+        (periodeId: string | null, kildeId: string | null, drawer: DrawerInnhold | null) => {
+            setAktivPeriodeId(periodeId)
+            setAktivDrawerKildeId(kildeId)
+            setDrawerInnhold(drawer)
+        },
+        [],
+    )
+
+    const handleDrawerValgt = useCallback((kildeId: string | null, drawer: DrawerInnhold | null) => {
         setAktivDrawerKildeId(kildeId)
         setDrawerInnhold(drawer)
-    }
+    }, [])
 
-    const handleDrawerValgt = (kildeId: string | null, drawer: DrawerInnhold | null) => {
-        setAktivDrawerKildeId(kildeId)
-        setDrawerInnhold(drawer)
-    }
-
-    const handleLukkDrawer = () => {
+    const handleLukkDrawer = useCallback(() => {
         setAktivDrawerKildeId(null)
         setDrawerInnhold(null)
-    }
+    }, [])
 
     return {
         filter,

--- a/src/utils/useValgtFnr.ts
+++ b/src/utils/useValgtFnr.ts
@@ -1,4 +1,4 @@
-import { createContext, createElement, ReactNode, useContext, useMemo, useState } from 'react'
+import { createContext, createElement, ReactNode, useCallback, useContext, useMemo, useState } from 'react'
 
 export type OppslagData = {
     sykmelding?: object
@@ -37,17 +37,17 @@ export const ValgtFnrProvider = ({ children }: { children: ReactNode }) => {
     const [valgtDrawerKildeId, setValgtDrawerKildeId] = useState<string | null>(null)
     const [oppslagData, setOppslagData] = useState<OppslagData>({})
 
-    const settValgtPeriode = (periodeId: string | null, kildeId?: string | null, data?: OppslagData) => {
+    const settValgtPeriode = useCallback((periodeId: string | null, kildeId?: string | null, data?: OppslagData) => {
         setValgtPeriodeId(periodeId ?? null)
         setValgtDrawerKildeId(kildeId ?? null)
         if (data) setOppslagData(data)
-    }
+    }, [])
 
-    const nullstillValgtPeriode = () => {
+    const nullstillValgtPeriode = useCallback(() => {
         setValgtPeriodeId(null)
         setValgtDrawerKildeId(null)
         setOppslagData({})
-    }
+    }, [])
 
     const verdi = useMemo(
         () => ({
@@ -60,7 +60,7 @@ export const ValgtFnrProvider = ({ children }: { children: ReactNode }) => {
             settValgtPeriode,
             nullstillValgtPeriode,
         }),
-        [fnr, valgtPeriodeId, valgtDrawerKildeId, oppslagData],
+        [fnr, valgtPeriodeId, valgtDrawerKildeId, oppslagData, settValgtPeriode, nullstillValgtPeriode],
     )
 
     return createElement(ValgtFnrContext.Provider, { value: verdi }, children)


### PR DESCRIPTION
## Problem

Når man søkte opp en ny sykmeldingId eller søknadId i `IdOppslagSokefelt` etter å ha gjort et tidligere søk, krasjet siden med «Maximum update depth exceeded».

## Rotårsak

To sammenkoblede render-løkker:

**Løkke A** – `IdOppslagSokefelt` ↔ kontekst:
- `settValgtPeriode` og `nullstillValgtPeriode` i `ValgtFnrProvider` var ikke stabile (manglende `useCallback`)
- Disse var i `useEffect`-deps i `IdOppslagSokefelt`
- Hvert kall til `settValgtPeriode` endret konteksten → ny referanse → effecten kjørte igjen → nytt kall osv.

**Løkke B** – `TidslinjeKombinert` ↔ `useTidslinjeKombinert`:
- `handlePeriodeValgt`, `handleDrawerValgt`, `handleLukkDrawer` ble gjenskapt ved hver re-render (ikke `useCallback`)
- `handlePeriodeValgt` var i `useEffect`-deps → effecten kjørte på nytt → timeren satte nye `Date`-objekter → ny re-render osv.

For første søk stoppet løkkene i tide pga. `setTimeout(() => setId(undefined), 0)`. For **andre søk** (spesielt når data er cachet og returneres umiddelbart av React Query) rekker løkkene å nå Reacts max-grense (~50 renders).

## Løsning

- `src/utils/useValgtFnr.ts`: `useCallback` rundt `settValgtPeriode` og `nullstillValgtPeriode`
- `src/components/kombinert/useTidslinjeKombinert.ts`: `useCallback` rundt `handlePeriodeValgt`, `handleDrawerValgt`, `handleLukkDrawer`
- Ny integrasjonstest som simulerer to påfølgende søk med reell `ValgtFnrProvider`