### PR TITLE
Kafkaformat-visning i detaljdrawer for søknader

### DIFF
--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -1,14 +1,18 @@
-import React, { useSyncExternalStore } from 'react'
+import React, { useState, useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, Heading } from '@navikt/ds-react'
+import { Button, Heading, ToggleGroup } from '@navikt/ds-react'
 import { XMarkIcon, SidebarRightIcon } from '@navikt/aksel-icons'
+
+import { useSoknadKafkaformat } from '../queryhooks/useSoknadKafkaformat'
 
 import { Detaljer } from './Detaljer'
 import { Filter } from './Filter'
 
+type VisModus = 'vanlig' | 'kafkaformat' | 'begge'
+
 type DrawerVariant =
     | { type: 'sykmelding'; objekt: object; periodeInfo: React.ReactNode }
-    | { type: 'soknad'; objekt: object; periodeInfo: React.ReactNode }
+    | { type: 'soknad'; soknadId: string; objekt: object; periodeInfo: React.ReactNode }
     | { type: 'klippetSoknad'; objekt: object }
 
 export interface DrawerInnhold {
@@ -39,21 +43,24 @@ export function lagSykmeldingDrawerInnhold(
 }
 
 export function lagSoknadDrawerInnhold(
-    soknad: object,
+    soknad: object & { id: string },
     periodeInfo: React.ReactNode,
     ikonHeader?: Array<{ ikon: React.ReactNode; tekst: string }>,
 ): DrawerInnhold {
     return {
         tittel: 'Søknad',
         ikonHeader,
-        variant: { type: 'soknad', objekt: soknad, periodeInfo },
+        variant: { type: 'soknad', soknadId: soknad.id, objekt: soknad, periodeInfo },
     }
 }
 
-export function lagOppholdUtlandSoknadDrawerInnhold(soknad: object, periodeInfo: React.ReactNode): DrawerInnhold {
+export function lagOppholdUtlandSoknadDrawerInnhold(
+    soknad: object & { id: string },
+    periodeInfo: React.ReactNode,
+): DrawerInnhold {
     return {
         tittel: 'Opphold utland søknad',
-        variant: { type: 'soknad', objekt: soknad, periodeInfo },
+        variant: { type: 'soknad', soknadId: soknad.id, objekt: soknad, periodeInfo },
     }
 }
 
@@ -64,20 +71,87 @@ export function lagKlippetSoknadDrawerInnhold(klippetSoknad: object): DrawerInnh
     }
 }
 
+function SoknadInnholdRenderer({
+    variant,
+    filter,
+    setFilter,
+    plassering,
+    visModus,
+}: {
+    variant: Extract<DrawerVariant, { type: 'soknad' }>
+    filter: Filter[]
+    setFilter: React.Dispatch<React.SetStateAction<Filter[]>>
+    plassering: 'bunn' | 'hoyre'
+    visModus: VisModus
+}) {
+    const [kafkaformatFilter, setKafkaformatFilter] = useState<Filter[]>([])
+    const { data: kafkaformatData } = useSoknadKafkaformat(
+        variant.soknadId,
+        visModus === 'kafkaformat' || visModus === 'begge',
+    )
+
+    const vanligDetaljer = <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
+    const kafkaDetaljer = kafkaformatData ? (
+        <Detaljer objekt={kafkaformatData} filter={kafkaformatFilter} setFilter={setKafkaformatFilter} />
+    ) : (
+        <span className="text-gray-400 text-sm">Laster kafkaformat...</span>
+    )
+
+    if (plassering === 'bunn') {
+        if (visModus === 'begge') {
+            return (
+                <div className="flex h-full gap-4">
+                    <div className="w-1/4 overflow-y-auto">{variant.periodeInfo}</div>
+                    <div className="w-[37.5%] overflow-y-auto">{vanligDetaljer}</div>
+                    <div className="w-[37.5%] overflow-y-auto">{kafkaDetaljer}</div>
+                </div>
+            )
+        }
+        return (
+            <div className="flex h-full gap-6">
+                <div className="w-1/2 overflow-y-auto">{variant.periodeInfo}</div>
+                <div className="w-1/2 overflow-y-auto">
+                    {visModus === 'kafkaformat' ? kafkaDetaljer : vanligDetaljer}
+                </div>
+            </div>
+        )
+    }
+
+    if (visModus === 'begge') {
+        return (
+            <div className="space-y-4">
+                {variant.periodeInfo}
+                <div className="flex gap-4">
+                    <div className="w-1/2 overflow-y-auto">{vanligDetaljer}</div>
+                    <div className="w-1/2 overflow-y-auto">{kafkaDetaljer}</div>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4">
+            {variant.periodeInfo}
+            {visModus === 'kafkaformat' ? kafkaDetaljer : vanligDetaljer}
+        </div>
+    )
+}
+
 function DrawerInnholdRenderer({
     variant,
     filter,
     setFilter,
     plassering,
+    visModus,
 }: {
     variant: DrawerVariant
     filter: Filter[]
     setFilter: React.Dispatch<React.SetStateAction<Filter[]>>
     plassering: 'bunn' | 'hoyre'
+    visModus: VisModus
 }) {
     switch (variant.type) {
         case 'sykmelding':
-        case 'soknad':
             if (plassering === 'bunn') {
                 return (
                     <div className="flex h-full gap-6">
@@ -93,6 +167,16 @@ function DrawerInnholdRenderer({
                     {variant.periodeInfo}
                     <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
                 </div>
+            )
+        case 'soknad':
+            return (
+                <SoknadInnholdRenderer
+                    variant={variant}
+                    filter={filter}
+                    setFilter={setFilter}
+                    plassering={plassering}
+                    visModus={visModus}
+                />
             )
         case 'klippetSoknad':
             return <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
@@ -112,8 +196,11 @@ export default function DetaljerDrawer({
         () => true,
         () => false,
     )
+    const [visModus, setVisModus] = useState<VisModus>('vanlig')
     const erApen = innhold !== null
     const erBunn = plassering === 'bunn'
+    const erSoknad = innhold?.variant.type === 'soknad'
+    const erBegge = visModus === 'begge'
 
     if (!mounted) return null
 
@@ -125,9 +212,10 @@ export default function DetaljerDrawer({
               erApen ? 'translate-y-0' : 'translate-y-full',
           ]
         : [
-              'fixed top-0 right-0 z-[99999] flex h-full w-[500px] flex-col',
+              'fixed top-0 right-0 z-[99999] flex h-full flex-col',
+              erSoknad && erBegge ? 'w-[900px]' : 'w-[500px]',
               'border-l border-gray-200 shadow-[-4px_0_24px_rgba(0,0,0,0.12)]',
-              'transition-transform duration-300 ease-in-out',
+              'transition-[transform,width] duration-300 ease-in-out',
               erApen ? 'translate-x-0' : 'translate-x-full',
           ]
 
@@ -155,7 +243,19 @@ export default function DetaljerDrawer({
                         </div>
                     )}
                 </div>
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-2">
+                    {erSoknad && (
+                        <ToggleGroup
+                            value={visModus}
+                            onChange={(v) => setVisModus(v as VisModus)}
+                            size="small"
+                            variant="neutral"
+                        >
+                            <ToggleGroup.Item value="vanlig">Vanlig</ToggleGroup.Item>
+                            <ToggleGroup.Item value="kafkaformat">Kafka</ToggleGroup.Item>
+                            <ToggleGroup.Item value="begge">Begge</ToggleGroup.Item>
+                        </ToggleGroup>
+                    )}
                     <Button
                         variant="tertiary"
                         size="small"
@@ -180,6 +280,7 @@ export default function DetaljerDrawer({
                         filter={filter}
                         setFilter={setFilter}
                         plassering={plassering}
+                        visModus={visModus}
                     />
                 )}
             </div>

--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -85,16 +85,15 @@ function SoknadInnholdRenderer({
     visModus: VisModus
 }) {
     const [kafkaformatFilter, setKafkaformatFilter] = useState<Filter[]>([])
-    const { data: kafkaformatData } = useSoknadKafkaformat(
-        variant.soknadId,
-        visModus === 'kafkaformat' || visModus === 'begge',
-    )
+    const { data: kafkaformatData, isLoading: lasterKafka } = useSoknadKafkaformat(variant.soknadId)
 
     const vanligDetaljer = <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
-    const kafkaDetaljer = kafkaformatData ? (
+    const kafkaDetaljer = lasterKafka ? (
+        <span className="text-gray-400 text-sm">Laster kafkaformat...</span>
+    ) : kafkaformatData ? (
         <Detaljer objekt={kafkaformatData} filter={kafkaformatFilter} setFilter={setKafkaformatFilter} />
     ) : (
-        <span className="text-gray-400 text-sm">Laster kafkaformat...</span>
+        <span className="text-gray-400 text-sm">Ingen kafkaformat-data</span>
     )
 
     if (plassering === 'bunn') {
@@ -251,7 +250,7 @@ export default function DetaljerDrawer({
                             size="small"
                             variant="neutral"
                         >
-                            <ToggleGroup.Item value="vanlig">Vanlig</ToggleGroup.Item>
+                            <ToggleGroup.Item value="vanlig">Detaljer</ToggleGroup.Item>
                             <ToggleGroup.Item value="kafkaformat">Kafka</ToggleGroup.Item>
                             <ToggleGroup.Item value="begge">Begge</ToggleGroup.Item>
                         </ToggleGroup>

--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -71,6 +71,21 @@ export function lagKlippetSoknadDrawerInnhold(klippetSoknad: object): DrawerInnh
     }
 }
 
+const SKJUL_I_DETALJER = new Set([
+    'id',
+    'sykmeldingId',
+    'status',
+    'arbeidssituasjon',
+    'ventetidSykmeldingUuid',
+    'fom',
+    'tom',
+    'soknadPerioder',
+])
+
+function filtrerNøkler(obj: object, skjul: Set<string>): object {
+    return Object.fromEntries(Object.entries(obj).filter(([k]) => !skjul.has(k)))
+}
+
 function SoknadInnholdRenderer({
     variant,
     filter,
@@ -87,11 +102,17 @@ function SoknadInnholdRenderer({
     const [kafkaformatFilter, setKafkaformatFilter] = useState<Filter[]>([])
     const { data: kafkaformatData, isLoading: lasterKafka } = useSoknadKafkaformat(variant.soknadId)
 
-    const vanligDetaljer = <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
+    const filtrertSoknad = filtrerNøkler(variant.objekt, SKJUL_I_DETALJER)
+    const vanligDetaljer = <Detaljer objekt={filtrertSoknad} filter={filter} setFilter={setFilter} />
+
     const kafkaDetaljer = lasterKafka ? (
         <span className="text-gray-400 text-sm">Laster kafkaformat...</span>
     ) : kafkaformatData ? (
-        <Detaljer objekt={kafkaformatData} filter={kafkaformatFilter} setFilter={setKafkaformatFilter} />
+        <Detaljer
+            objekt={filtrerNøkler(kafkaformatData, new Set(['versjon']))}
+            filter={kafkaformatFilter}
+            setFilter={setKafkaformatFilter}
+        />
     ) : (
         <span className="text-gray-400 text-sm">Ingen kafkaformat-data</span>
     )

--- a/src/components/periodeinfo/ViktigeFeltForSoknad.tsx
+++ b/src/components/periodeinfo/ViktigeFeltForSoknad.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Button } from '@navikt/ds-react'
 
 import { Soknad, dayjsToDate } from '../../queryhooks/useSoknader'
 import { antallKalenderdager, formaterDato } from '../sykmelding/sykmeldingTidslinjeUtils'
+import { useSoknadKafkaformat } from '../../queryhooks/useSoknadKafkaformat'
+import { Detaljer } from '../Detaljer'
 
 import ViktigePeriodefelt from './ViktigePeriodefelt'
 
@@ -38,6 +41,10 @@ const hentGradFraSoknadperioder = (soknad: Soknad): string => {
 }
 
 export default function ViktigeFeltForSoknad({ soknad }: Props) {
+    const [visKafkaformat, setVisKafkaformat] = useState(false)
+    const [kafkaformatFilter, setKafkaformatFilter] = useState<import('../Filter').Filter[]>([])
+    const { data: kafkaformatData } = useSoknadKafkaformat(soknad.id, visKafkaformat)
+
     if (soknad.soknadstype === 'OPPHOLD_UTLAND') {
         const opprettetDato = dayjsToDate(soknad.opprettetDato)
         if (!opprettetDato) return null
@@ -48,7 +55,18 @@ export default function ViktigeFeltForSoknad({ soknad }: Props) {
             { etikett: 'Opprettet dato', verdi: formaterDato(opprettetDato) },
         ]
 
-        return <ViktigePeriodefelt viktigeFelt={viktigeFelt} />
+        return (
+            <div className="space-y-3">
+                <ViktigePeriodefelt viktigeFelt={viktigeFelt} />
+                <KafkaformatSeksjon
+                    visKafkaformat={visKafkaformat}
+                    setVisKafkaformat={setVisKafkaformat}
+                    kafkaformatData={kafkaformatData}
+                    kafkaformatFilter={kafkaformatFilter}
+                    setKafkaformatFilter={setKafkaformatFilter}
+                />
+            </div>
+        )
     }
 
     const perioder = soknad.soknadPerioder
@@ -91,5 +109,43 @@ export default function ViktigeFeltForSoknad({ soknad }: Props) {
         (periode, indeks) => `${indeks + 1}: ${formaterDato(periode.startDato)} – ${formaterDato(periode.sluttDato)}`,
     )
 
-    return <ViktigePeriodefelt viktigeFelt={viktigeFelt} delperiodeTekster={delperiodeTekster} />
+    return (
+        <div className="space-y-3">
+            <ViktigePeriodefelt viktigeFelt={viktigeFelt} delperiodeTekster={delperiodeTekster} />
+            <KafkaformatSeksjon
+                visKafkaformat={visKafkaformat}
+                setVisKafkaformat={setVisKafkaformat}
+                kafkaformatData={kafkaformatData}
+                kafkaformatFilter={kafkaformatFilter}
+                setKafkaformatFilter={setKafkaformatFilter}
+            />
+        </div>
+    )
+}
+
+interface KafkaformatSeksjonProps {
+    visKafkaformat: boolean
+    setVisKafkaformat: React.Dispatch<React.SetStateAction<boolean>>
+    kafkaformatData: object | null | undefined
+    kafkaformatFilter: import('../Filter').Filter[]
+    setKafkaformatFilter: React.Dispatch<React.SetStateAction<import('../Filter').Filter[]>>
+}
+
+function KafkaformatSeksjon({
+    visKafkaformat,
+    setVisKafkaformat,
+    kafkaformatData,
+    kafkaformatFilter,
+    setKafkaformatFilter,
+}: KafkaformatSeksjonProps) {
+    return (
+        <div className="space-y-2">
+            <Button variant="secondary" size="small" onClick={() => setVisKafkaformat((prev) => !prev)}>
+                {visKafkaformat ? 'Skjul kafkaformat' : 'Vis kafkaformat'}
+            </Button>
+            {visKafkaformat && kafkaformatData && (
+                <Detaljer objekt={kafkaformatData} filter={kafkaformatFilter} setFilter={setKafkaformatFilter} />
+            )}
+        </div>
+    )
 }

--- a/src/components/periodeinfo/ViktigeFeltForSoknad.tsx
+++ b/src/components/periodeinfo/ViktigeFeltForSoknad.tsx
@@ -1,10 +1,7 @@
-import React, { useState } from 'react'
-import { Button } from '@navikt/ds-react'
+import React from 'react'
 
 import { Soknad, dayjsToDate } from '../../queryhooks/useSoknader'
 import { antallKalenderdager, formaterDato } from '../sykmelding/sykmeldingTidslinjeUtils'
-import { useSoknadKafkaformat } from '../../queryhooks/useSoknadKafkaformat'
-import { Detaljer } from '../Detaljer'
 
 import ViktigePeriodefelt from './ViktigePeriodefelt'
 
@@ -41,10 +38,6 @@ const hentGradFraSoknadperioder = (soknad: Soknad): string => {
 }
 
 export default function ViktigeFeltForSoknad({ soknad }: Props) {
-    const [visKafkaformat, setVisKafkaformat] = useState(false)
-    const [kafkaformatFilter, setKafkaformatFilter] = useState<import('../Filter').Filter[]>([])
-    const { data: kafkaformatData } = useSoknadKafkaformat(soknad.id, visKafkaformat)
-
     if (soknad.soknadstype === 'OPPHOLD_UTLAND') {
         const opprettetDato = dayjsToDate(soknad.opprettetDato)
         if (!opprettetDato) return null
@@ -55,18 +48,7 @@ export default function ViktigeFeltForSoknad({ soknad }: Props) {
             { etikett: 'Opprettet dato', verdi: formaterDato(opprettetDato) },
         ]
 
-        return (
-            <div className="space-y-3">
-                <ViktigePeriodefelt viktigeFelt={viktigeFelt} />
-                <KafkaformatSeksjon
-                    visKafkaformat={visKafkaformat}
-                    setVisKafkaformat={setVisKafkaformat}
-                    kafkaformatData={kafkaformatData}
-                    kafkaformatFilter={kafkaformatFilter}
-                    setKafkaformatFilter={setKafkaformatFilter}
-                />
-            </div>
-        )
+        return <ViktigePeriodefelt viktigeFelt={viktigeFelt} />
     }
 
     const perioder = soknad.soknadPerioder
@@ -109,43 +91,5 @@ export default function ViktigeFeltForSoknad({ soknad }: Props) {
         (periode, indeks) => `${indeks + 1}: ${formaterDato(periode.startDato)} – ${formaterDato(periode.sluttDato)}`,
     )
 
-    return (
-        <div className="space-y-3">
-            <ViktigePeriodefelt viktigeFelt={viktigeFelt} delperiodeTekster={delperiodeTekster} />
-            <KafkaformatSeksjon
-                visKafkaformat={visKafkaformat}
-                setVisKafkaformat={setVisKafkaformat}
-                kafkaformatData={kafkaformatData}
-                kafkaformatFilter={kafkaformatFilter}
-                setKafkaformatFilter={setKafkaformatFilter}
-            />
-        </div>
-    )
-}
-
-interface KafkaformatSeksjonProps {
-    visKafkaformat: boolean
-    setVisKafkaformat: React.Dispatch<React.SetStateAction<boolean>>
-    kafkaformatData: object | null | undefined
-    kafkaformatFilter: import('../Filter').Filter[]
-    setKafkaformatFilter: React.Dispatch<React.SetStateAction<import('../Filter').Filter[]>>
-}
-
-function KafkaformatSeksjon({
-    visKafkaformat,
-    setVisKafkaformat,
-    kafkaformatData,
-    kafkaformatFilter,
-    setKafkaformatFilter,
-}: KafkaformatSeksjonProps) {
-    return (
-        <div className="space-y-2">
-            <Button variant="secondary" size="small" onClick={() => setVisKafkaformat((prev) => !prev)}>
-                {visKafkaformat ? 'Skjul kafkaformat' : 'Vis kafkaformat'}
-            </Button>
-            {visKafkaformat && kafkaformatData && (
-                <Detaljer objekt={kafkaformatData} filter={kafkaformatFilter} setFilter={setKafkaformatFilter} />
-            )}
-        </div>
-    )
+    return <ViktigePeriodefelt viktigeFelt={viktigeFelt} delperiodeTekster={delperiodeTekster} />
 }


### PR DESCRIPTION
Legger til mulighet for å vise søknadsdata i kafkaformat direkte fra detaljvisningen i tidslinjen.

## Endringer

- **ToggleGroup i drawer-headeren** for søknadsperioder med tre valg: *Detaljer* / *Kafka* / *Begge*
- Kafkaformat-data vises med samme `<Detaljer>`-komponent som resten av draweren
- *Begge*-modus viser detaljer og kafkaformat side om side (drawer utvides til 900px i høyre-modus)
- Duplikatfelt skjult i detaljer-visningen (felt allerede vist i periodeinfo-kortet)
- `versjon`-feltet skjult i kafkaformat-visningen