### PR TITLE
Vis rike detaljer direkte ved oppslag på søknad-ID

### DIFF
--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -2,8 +2,9 @@ import React, { useEffect } from 'react'
 import { BodyShort } from '@navikt/ds-react'
 import dayjs from 'dayjs'
 
-import { KlippetSykepengesoknadRecord, Soknad, dayjsToDate } from '../queryhooks/useSoknader'
+import { BackendSoknad, KlippetSykepengesoknadRecord, Soknad, dayjsToDate } from '../queryhooks/useSoknader'
 import type { Sykmelding } from '../queryhooks/useSykmeldinger'
+import { ikonParForSoknad } from '../utils/tidslinjeIkonUtils'
 import { useValgtFnr } from '../utils/useValgtFnr'
 
 import { ValgteFilter } from './Filter'
@@ -12,6 +13,7 @@ import DetaljerDrawer, { lagSykmeldingDrawerInnhold, lagSoknadDrawerInnhold } fr
 import { useTidslinjeKombinert } from './kombinert/useTidslinjeKombinert'
 import SykmeldingTidslinje from './kombinert/SykmeldingTidslinje'
 import SoknadTidslinje from './kombinert/SoknadTidslinje'
+import ViktigeFeltForSoknad from './periodeinfo/ViktigeFeltForSoknad'
 import ViktigeFeltForSykmelding from './periodeinfo/ViktigeFeltForSykmelding'
 import { perioderMedDatoer, sorterPerioder } from './sykmelding/sykmeldingTidslinjeUtils'
 
@@ -65,17 +67,11 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                     periodEnd = perioder[perioder.length - 1].sluttDato
                 }
             } else if (oppslagData?.soknad) {
-                const soknad = oppslagData.soknad as Soknad
-                const fomDato = dayjsToDate(soknad.fom as string | undefined)
-                const tomDato = dayjsToDate(soknad.tom as string | undefined)
-                const fom = fomDato ? dayjs(fomDato).format('DD.MM.YYYY') : '–'
-                const tom = tomDato ? dayjs(tomDato).format('DD.MM.YYYY') : '–'
-                const periodeInfo = (
-                    <div>
-                        {fom} til {tom}
-                    </div>
-                )
-                drawerContent = lagSoknadDrawerInnhold(soknad, periodeInfo)
+                const soknad = new Soknad(oppslagData.soknad as BackendSoknad)
+                const fomDato = dayjsToDate(soknad.fom)
+                const tomDato = dayjsToDate(soknad.tom)
+                const periodeInfo = <ViktigeFeltForSoknad soknad={soknad} />
+                drawerContent = lagSoknadDrawerInnhold(soknad, periodeInfo, ikonParForSoknad(soknad))
                 periodStart = fomDato ?? null
                 periodEnd = tomDato ?? null
             }


### PR DESCRIPTION
## Problem

Ved oppslag på sykepengesoknadId åpnet draweren med minimalt innhold — kun en enkel dato-streng (`{fom} til {tom}`) som periodeInfo, uten status, grad, ikoner eller andre viktige felt. Brukeren måtte lukke og klikke søknaden i tidslinjen for å se full informasjon.

## Årsak

`oppslagData.soknad` fra id-oppslaget er rå backend-JSON (ikke en `Soknad`-klasseinstans med Dayjs-datoer). Den eksisterende koden behandlet dette som en `Soknad`-instans og bygget en forenklet `periodeInfo` uten å bruke `ViktigeFeltForSoknad` eller `ikonParForSoknad`.

## Løsning

Konverterer nå rå backend-objekt til en `Soknad`-instans med `new Soknad(backendSoknad)`, og bruker `<ViktigeFeltForSoknad soknad={soknad} />` og `ikonParForSoknad(soknad)` — nøyaktig samme visning som ved klikk i tidslinjen.

## Endringer

- `src/components/TidslinjeKombinert.tsx`: Bruker `new Soknad()` + `ViktigeFeltForSoknad` + `ikonParForSoknad` ved soknad-ID-oppslag

## Test

Alle 143 eksisterende tester passerer.