### PR TITLE
Oppgraderer Distroless til nodejs24-debian13@sha256:10e26238

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian13@sha256:e70510b44870c5686983f2b11f22b884f2dfacf86aea69b6b0edb2ccb3f237f4
+FROM gcr.io/distroless/nodejs24-debian13@sha256:10e262383ceb3a2a5f6f5ceaca5ecebe74951eff21868a055589676eec3a8001
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Fra flex-cli