### PR TITLE
Søk på aktørId direkte i fnr-feltet

### DIFF
--- a/src/components/FnrSokefelt.tsx
+++ b/src/components/FnrSokefelt.tsx
@@ -88,6 +88,9 @@ const FnrSokefelt = ({
             return
         }
 
+        // Avbryt evt. pågående aktørId-oppslag før vi setter fnr direkte
+        settAktorId(undefined)
+
         const erSammeFnr = validertVerdi === fnr
         settFnr(validertVerdi)
 
@@ -120,6 +123,8 @@ const FnrSokefelt = ({
                     setSokeverdi(verdi)
                     settFunnetFnr(undefined)
                     fnrFraAktorIdRef.current = undefined
+                    // Avbryt evt. pågående aktørId-oppslag (unngår race condition)
+                    settAktorId(undefined)
                     if (feilmelding) {
                         setFeilmelding(undefined)
                     }

--- a/src/components/FnrSokefelt.tsx
+++ b/src/components/FnrSokefelt.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
-import { InlineMessage, Search } from '@navikt/ds-react'
+import { BodyShort, Button, InlineMessage, Search } from '@navikt/ds-react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { validerFnr, validerIdent } from '../utils/inputValidering'
@@ -96,6 +96,14 @@ const FnrSokefelt = ({
         }
     }
 
+    const velgFnr = (valgtFnr: string) => {
+        fnrFraAktorIdRef.current = valgtFnr
+        settFunnetFnr(valgtFnr)
+        settFnr(valgtFnr)
+        settAktorId(undefined)
+        setFeilmelding(undefined)
+    }
+
     const dynamiskDescription =
         valideringstype === 'fnrEllerAktorId' && resultat.status === 'laster' ? 'Slår opp aktørId...' : description
 
@@ -129,6 +137,20 @@ const FnrSokefelt = ({
                 <InlineMessage status="success" size="small" className="mt-1">
                     Fant fnr: {funnetFnr}
                 </InlineMessage>
+            )}
+            {resultat.status === 'flereFunnet' && (
+                <div className="mt-2 space-y-1">
+                    <BodyShort size="small" weight="semibold">
+                        Flere fødselsnummer funnet – velg:
+                    </BodyShort>
+                    <div className="flex flex-wrap gap-2">
+                        {resultat.fnrListe.map((f) => (
+                            <Button key={f} variant="secondary" size="small" onClick={() => velgFnr(f)}>
+                                {f}
+                            </Button>
+                        ))}
+                    </div>
+                </div>
             )}
         </div>
     )

--- a/src/components/FnrSokefelt.tsx
+++ b/src/components/FnrSokefelt.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { Search } from '@navikt/ds-react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { InlineMessage, Search } from '@navikt/ds-react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { validerFnr, validerIdent } from '../utils/inputValidering'
@@ -39,10 +39,15 @@ const FnrSokefelt = ({
     const queryClient = useQueryClient()
     const [sokeverdi, setSokeverdi] = useState(fnr ?? '')
     const [feilmelding, setFeilmelding] = useState<string>()
+    const [funnetFnr, settFunnetFnr] = useState<string | undefined>()
+    // Ref for å unngå at sync-effekten overskriver søkefeltet ved aktørId-oppslag
+    const fnrFraAktorIdRef = useRef<string | undefined>()
 
     const onAktorIdFunnet = useCallback(
-        (funnetFnr: string) => {
-            settFnr(funnetFnr)
+        (losnetFnr: string) => {
+            fnrFraAktorIdRef.current = losnetFnr
+            settFunnetFnr(losnetFnr)
+            settFnr(losnetFnr)
             setFeilmelding(undefined)
         },
         [settFnr],
@@ -56,9 +61,10 @@ const FnrSokefelt = ({
         nullstillFnr()
     }, [resultat, nullstillFnr])
 
-    // Synkroniser søkefeltet med valgt fnr fra context slik at feltet fylles
-    // når et id-oppslag treffer
+    // Synkroniser søkefeltet med valgt fnr fra context – men ikke når fnr kom fra aktørId-oppslag
+    // (da skal søkefeltet vise aktørId-en som ble søkt på, ikke det løste fnr)
     useEffect(() => {
+        if (fnrFraAktorIdRef.current === fnr) return
         const timer = setTimeout(() => setSokeverdi(fnr ?? ''), 0)
         return () => clearTimeout(timer)
     }, [fnr])
@@ -76,6 +82,8 @@ const FnrSokefelt = ({
         setFeilmelding(undefined)
 
         if (valideringstype === 'fnrEllerAktorId' && validertVerdi.length === 13) {
+            settFunnetFnr(undefined)
+            fnrFraAktorIdRef.current = undefined
             settAktorId(validertVerdi)
             return
         }
@@ -88,31 +96,41 @@ const FnrSokefelt = ({
         }
     }
 
+    const dynamiskDescription =
+        valideringstype === 'fnrEllerAktorId' && resultat.status === 'laster' ? 'Slår opp aktørId...' : description
+
     return (
-        <Search
-            key={fnr ?? 'tomt-fnr'}
-            className={className}
-            hideLabel={false}
-            htmlSize={htmlSize}
-            label={label}
-            description={description}
-            value={sokeverdi}
-            error={feilmelding ?? (resultat.status === 'feil' ? resultat.melding : undefined)}
-            onChange={(verdi) => {
-                setSokeverdi(verdi)
-                if (feilmelding) {
-                    setFeilmelding(undefined)
-                }
-            }}
-            onSearchClick={handterSok}
-            onKeyDown={(evt) => {
-                if (evt.key === 'Enter') {
-                    handterSok(evt.currentTarget.value)
-                }
-            }}
-        >
-            <Search.Button loading={resultat.status === 'laster'} />
-        </Search>
+        <div className={className}>
+            <Search
+                hideLabel={false}
+                htmlSize={htmlSize}
+                label={label}
+                description={dynamiskDescription}
+                value={sokeverdi}
+                error={feilmelding ?? (resultat.status === 'feil' ? resultat.melding : undefined)}
+                onChange={(verdi) => {
+                    setSokeverdi(verdi)
+                    settFunnetFnr(undefined)
+                    fnrFraAktorIdRef.current = undefined
+                    if (feilmelding) {
+                        setFeilmelding(undefined)
+                    }
+                }}
+                onSearchClick={handterSok}
+                onKeyDown={(evt) => {
+                    if (evt.key === 'Enter') {
+                        handterSok(evt.currentTarget.value)
+                    }
+                }}
+            >
+                <Search.Button loading={resultat.status === 'laster'} />
+            </Search>
+            {funnetFnr && (
+                <InlineMessage status="success" size="small" className="mt-1">
+                    Fant fnr: {funnetFnr}
+                </InlineMessage>
+            )}
+        </div>
     )
 }
 

--- a/src/components/FnrSokefelt.tsx
+++ b/src/components/FnrSokefelt.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { Search } from '@navikt/ds-react'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { validerFnr, validerIdent } from '../utils/inputValidering'
 import { useValgtFnr } from '../utils/useValgtFnr'
+import { useAktorIdOppslag } from '../utils/useAktorIdOppslag'
 
-type Valideringstype = 'fnr' | 'ident'
+type Valideringstype = 'fnr' | 'ident' | 'fnrEllerAktorId'
 
 type Props = {
     className?: string
@@ -18,11 +19,13 @@ type Props = {
 const feilmeldinger: Record<Valideringstype, string> = {
     fnr: 'Fødselsnummer må være 11 siffer',
     ident: 'Ident må være 11 eller 13 siffer',
+    fnrEllerAktorId: 'Skriv inn 11-sifret fnr eller 13-sifret aktørId',
 }
 
 const valideringsfunksjoner: Record<Valideringstype, (input: string) => string | null> = {
     fnr: validerFnr,
     ident: validerIdent,
+    fnrEllerAktorId: validerIdent,
 }
 
 const FnrSokefelt = ({
@@ -36,6 +39,22 @@ const FnrSokefelt = ({
     const queryClient = useQueryClient()
     const [sokeverdi, setSokeverdi] = useState(fnr ?? '')
     const [feilmelding, setFeilmelding] = useState<string>()
+
+    const onAktorIdFunnet = useCallback(
+        (funnetFnr: string) => {
+            settFnr(funnetFnr)
+            setFeilmelding(undefined)
+        },
+        [settFnr],
+    )
+
+    const { settAktorId, resultat } = useAktorIdOppslag(onAktorIdFunnet)
+
+    // Nullstill fnr ved feilet aktørId-oppslag (nullstillFnr er en kontekst-setter, ikke lokal state)
+    useEffect(() => {
+        if (resultat.status !== 'feil') return
+        nullstillFnr()
+    }, [resultat, nullstillFnr])
 
     // Synkroniser søkefeltet med valgt fnr fra context slik at feltet fylles
     // når et id-oppslag treffer
@@ -56,6 +75,11 @@ const FnrSokefelt = ({
 
         setFeilmelding(undefined)
 
+        if (valideringstype === 'fnrEllerAktorId' && validertVerdi.length === 13) {
+            settAktorId(validertVerdi)
+            return
+        }
+
         const erSammeFnr = validertVerdi === fnr
         settFnr(validertVerdi)
 
@@ -73,7 +97,7 @@ const FnrSokefelt = ({
             label={label}
             description={description}
             value={sokeverdi}
-            error={feilmelding}
+            error={feilmelding ?? (resultat.status === 'feil' ? resultat.melding : undefined)}
             onChange={(verdi) => {
                 setSokeverdi(verdi)
                 if (feilmelding) {
@@ -86,7 +110,9 @@ const FnrSokefelt = ({
                     handterSok(evt.currentTarget.value)
                 }
             }}
-        />
+        >
+            <Search.Button loading={resultat.status === 'laster'} />
+        </Search>
     )
 }
 

--- a/src/components/IdOppslagSokefelt.tsx
+++ b/src/components/IdOppslagSokefelt.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Alert, Search } from '@navikt/ds-react'
+import { InlineMessage, Search } from '@navikt/ds-react'
 
 import { useSoknad } from '../queryhooks/useSoknad'
 import { useSykmelding } from '../queryhooks/useSykmelding'
@@ -78,9 +78,9 @@ export const IdOppslagSokefelt = () => {
                 }}
             />
             {ikkeFunnet && (
-                <Alert variant="warning" className="mt-2">
+                <InlineMessage status="warning" role="alert" className="mt-2">
                     Fant ikke fnr for oppgitt ID
-                </Alert>
+                </InlineMessage>
             )}
         </>
     )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,11 @@ const Index = () => {
     return (
         <div className="space-y-4">
             <div className="inline-flex items-end gap-4">
-                <FnrSokefelt label="Fødselsnummer" description="Søk direkte på 11-sifret fødselsnummer" />
+                <FnrSokefelt
+                    label="Fødselsnummer eller aktørId"
+                    description="11-sifret fnr eller 13-sifret aktørId"
+                    valideringstype="fnrEllerAktorId"
+                />
                 <IdOppslagSokefelt />
             </div>
             <TidslinjeKombinert sykmeldinger={sykmeldinger} soknader={soknader} klipp={klipp} />

--- a/src/queryhooks/useIdenter.ts
+++ b/src/queryhooks/useIdenter.ts
@@ -5,6 +5,7 @@ import { fetchJsonMedRequestId } from '../utils/fetch'
 interface IdentData {
     gruppe: string
     ident: string
+    historisk?: boolean
 }
 
 export interface HentIdenterRequest {

--- a/src/testdata/testdata.ts
+++ b/src/testdata/testdata.ts
@@ -345,12 +345,13 @@ export async function mockApi(opts: BackendProxyOpts): Promise<void> {
         const body = await parseRequest<HentIdenterRequest>(req)
         res.status(200)
         res.json([
-            { gruppe: 'FOLKEREGISTERIDENT', ident: body.ident },
+            { gruppe: 'FOLKEREGISTERIDENT', ident: body.ident, historisk: false },
             {
                 gruppe: 'FOLKEREGISTERIDENT',
                 ident: '11111111111',
+                historisk: true,
             },
-            { gruppe: 'AKTORID', ident: '1111111111122' },
+            { gruppe: 'AKTORID', ident: '1111111111122', historisk: false },
         ])
         res.end()
         return

--- a/src/utils/inputValidering.ts
+++ b/src/utils/inputValidering.ts
@@ -54,7 +54,7 @@ export function validerUuid(input: string): string | null {
 
 export function validerIdent(input: string): string | null {
     const trimmed = input.trim()
-    if (trimmed.length === 11 || trimmed.length === 13) {
+    if ((trimmed.length === 11 || trimmed.length === 13) && /^\d+$/.test(trimmed)) {
         return trimmed
     }
     return null

--- a/src/utils/useAktorIdOppslag.test.ts
+++ b/src/utils/useAktorIdOppslag.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+import { useAktorIdOppslag } from './useAktorIdOppslag'
+
+const mockUseIdenter = vi.fn()
+
+vi.mock('../queryhooks/useIdenter', () => ({
+    useIdenter: (...args: unknown[]) => mockUseIdenter(...args),
+}))
+
+function wrapper({ children }: { children: React.ReactNode }) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
+describe('useAktorIdOppslag', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockUseIdenter.mockReturnValue({ data: undefined, isLoading: false, isError: false })
+    })
+
+    it('starter med status inaktiv', () => {
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        expect(result.current.resultat.status).toBe('inaktiv')
+    })
+
+    it('setter status laster under oppslag', async () => {
+        mockUseIdenter.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(result.current.resultat.status).toBe('laster'))
+    })
+
+    it('kaller onFunnet med fnr når FOLKEREGISTERIDENT finnes', async () => {
+        const onFunnet = vi.fn()
+        mockUseIdenter.mockReturnValue({
+            data: [
+                { gruppe: 'AKTORID', ident: '1234567890123' },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901' },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(onFunnet), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(onFunnet).toHaveBeenCalledWith('12345678901'))
+        expect(result.current.resultat.status).toBe('funnet')
+    })
+
+    it('setter status feil når ingen FOLKEREGISTERIDENT finnes', async () => {
+        const onFunnet = vi.fn()
+        mockUseIdenter.mockReturnValue({
+            data: [{ gruppe: 'AKTORID', ident: '1234567890123' }],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(onFunnet), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(result.current.resultat.status).toBe('feil'))
+        expect(onFunnet).not.toHaveBeenCalled()
+        if (result.current.resultat.status === 'feil') {
+            expect(result.current.resultat.melding).toBe('Fant ikke fødselsnummer for oppgitt aktørId')
+        }
+    })
+
+    it('setter status feil ved API-feil', async () => {
+        mockUseIdenter.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(result.current.resultat.status).toBe('feil'))
+        if (result.current.resultat.status === 'feil') {
+            expect(result.current.resultat.melding).toBe('Feil ved oppslag av aktørId')
+        }
+    })
+
+    it('resetter til inaktiv når settAktorId kalles med undefined', async () => {
+        const onFunnet = vi.fn()
+        mockUseIdenter.mockReturnValue({
+            data: [{ gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901' }],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(onFunnet), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+        await waitFor(() => expect(result.current.resultat.status).toBe('funnet'))
+
+        act(() => result.current.settAktorId(undefined))
+        expect(result.current.resultat.status).toBe('inaktiv')
+    })
+})

--- a/src/utils/useAktorIdOppslag.test.ts
+++ b/src/utils/useAktorIdOppslag.test.ts
@@ -36,12 +36,12 @@ describe('useAktorIdOppslag', () => {
         await waitFor(() => expect(result.current.resultat.status).toBe('laster'))
     })
 
-    it('kaller onFunnet med fnr når FOLKEREGISTERIDENT finnes', async () => {
+    it('kaller onFunnet med fnr når én aktiv FOLKEREGISTERIDENT finnes', async () => {
         const onFunnet = vi.fn()
         mockUseIdenter.mockReturnValue({
             data: [
-                { gruppe: 'AKTORID', ident: '1234567890123' },
-                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901' },
+                { gruppe: 'AKTORID', ident: '1234567890123', historisk: false },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: false },
             ],
             isLoading: false,
             isError: false,
@@ -53,6 +53,61 @@ describe('useAktorIdOppslag', () => {
         await waitFor(() => expect(onFunnet).toHaveBeenCalledWith('12345678901'))
         // Etter oppslag resetter hooken seg til inaktiv
         await waitFor(() => expect(result.current.resultat.status).toBe('inaktiv'))
+    })
+
+    it('bruker aktiv ident og ignorerer historisk når begge finnes', async () => {
+        const onFunnet = vi.fn()
+        mockUseIdenter.mockReturnValue({
+            data: [
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: false },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '98765432109', historisk: true },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(onFunnet), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(onFunnet).toHaveBeenCalledWith('12345678901'))
+    })
+
+    it('returnerer flereFunnet når to aktive FOLKEREGISTERIDENT finnes', async () => {
+        mockUseIdenter.mockReturnValue({
+            data: [
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: false },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '11111111111', historisk: false },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(result.current.resultat.status).toBe('flereFunnet'))
+        if (result.current.resultat.status === 'flereFunnet') {
+            expect(result.current.resultat.fnrListe).toEqual(['12345678901', '11111111111'])
+        }
+    })
+
+    it('returnerer flereFunnet for alle historiske når ingen aktive finnes', async () => {
+        mockUseIdenter.mockReturnValue({
+            data: [
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: true },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '11111111111', historisk: true },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+
+        await waitFor(() => expect(result.current.resultat.status).toBe('flereFunnet'))
+        if (result.current.resultat.status === 'flereFunnet') {
+            expect(result.current.resultat.fnrListe).toHaveLength(2)
+        }
     })
 
     it('setter status feil når ingen FOLKEREGISTERIDENT finnes', async () => {
@@ -88,7 +143,7 @@ describe('useAktorIdOppslag', () => {
     it('resetter til inaktiv etter vellykket oppslag', async () => {
         const onFunnet = vi.fn()
         mockUseIdenter.mockReturnValue({
-            data: [{ gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901' }],
+            data: [{ gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: false }],
             isLoading: false,
             isError: false,
         })
@@ -99,5 +154,23 @@ describe('useAktorIdOppslag', () => {
 
         // Etter timeout resettes aktorId → status inaktiv
         await waitFor(() => expect(result.current.resultat.status).toBe('inaktiv'))
+    })
+
+    it('forblir flereFunnet til bruker manuelt resetter med settAktorId(undefined)', async () => {
+        mockUseIdenter.mockReturnValue({
+            data: [
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901', historisk: false },
+                { gruppe: 'FOLKEREGISTERIDENT', ident: '11111111111', historisk: false },
+            ],
+            isLoading: false,
+            isError: false,
+        })
+
+        const { result } = renderHook(() => useAktorIdOppslag(vi.fn()), { wrapper })
+        act(() => result.current.settAktorId('1234567890123'))
+        await waitFor(() => expect(result.current.resultat.status).toBe('flereFunnet'))
+
+        act(() => result.current.settAktorId(undefined))
+        expect(result.current.resultat.status).toBe('inaktiv')
     })
 })

--- a/src/utils/useAktorIdOppslag.test.ts
+++ b/src/utils/useAktorIdOppslag.test.ts
@@ -51,7 +51,8 @@ describe('useAktorIdOppslag', () => {
         act(() => result.current.settAktorId('1234567890123'))
 
         await waitFor(() => expect(onFunnet).toHaveBeenCalledWith('12345678901'))
-        expect(result.current.resultat.status).toBe('funnet')
+        // Etter oppslag resetter hooken seg til inaktiv
+        await waitFor(() => expect(result.current.resultat.status).toBe('inaktiv'))
     })
 
     it('setter status feil når ingen FOLKEREGISTERIDENT finnes', async () => {
@@ -84,7 +85,7 @@ describe('useAktorIdOppslag', () => {
         }
     })
 
-    it('resetter til inaktiv når settAktorId kalles med undefined', async () => {
+    it('resetter til inaktiv etter vellykket oppslag', async () => {
         const onFunnet = vi.fn()
         mockUseIdenter.mockReturnValue({
             data: [{ gruppe: 'FOLKEREGISTERIDENT', ident: '12345678901' }],
@@ -94,9 +95,9 @@ describe('useAktorIdOppslag', () => {
 
         const { result } = renderHook(() => useAktorIdOppslag(onFunnet), { wrapper })
         act(() => result.current.settAktorId('1234567890123'))
-        await waitFor(() => expect(result.current.resultat.status).toBe('funnet'))
+        await waitFor(() => expect(onFunnet).toHaveBeenCalledWith('12345678901'))
 
-        act(() => result.current.settAktorId(undefined))
-        expect(result.current.resultat.status).toBe('inaktiv')
+        // Etter timeout resettes aktorId → status inaktiv
+        await waitFor(() => expect(result.current.resultat.status).toBe('inaktiv'))
     })
 })

--- a/src/utils/useAktorIdOppslag.ts
+++ b/src/utils/useAktorIdOppslag.ts
@@ -7,6 +7,7 @@ type AktorIdOppslagResultat =
     | { status: 'laster' }
     | { status: 'feil'; melding: string }
     | { status: 'funnet'; fnr: string }
+    | { status: 'flereFunnet'; fnrListe: string[] }
 
 export function useAktorIdOppslag(onFunnet: (fnr: string) => void): {
     settAktorId: (aktorId: string | undefined) => void
@@ -21,15 +22,27 @@ export function useAktorIdOppslag(onFunnet: (fnr: string) => void): {
         if (isLoading) return { status: 'laster' }
         if (isError) return { status: 'feil', melding: 'Feil ved oppslag av aktørId' }
         if (!identer) return { status: 'laster' }
-        const folkeregisterIdent = identer.find((i) => i.gruppe === 'FOLKEREGISTERIDENT')
-        if (folkeregisterIdent) return { status: 'funnet', fnr: folkeregisterIdent.ident }
-        return { status: 'feil', melding: 'Fant ikke fødselsnummer for oppgitt aktørId' }
+
+        const folkeregisterIdenter = identer.filter((i) => i.gruppe === 'FOLKEREGISTERIDENT')
+        if (folkeregisterIdenter.length === 0) {
+            return { status: 'feil', melding: 'Fant ikke fødselsnummer for oppgitt aktørId' }
+        }
+
+        // Foretrekk aktive (ikke-historiske) identer
+        const aktive = folkeregisterIdenter.filter((i) => !i.historisk)
+        const kandidater = aktive.length > 0 ? aktive : folkeregisterIdenter
+
+        if (kandidater.length === 1) {
+            return { status: 'funnet', fnr: kandidater[0].ident }
+        }
+        return { status: 'flereFunnet', fnrListe: kandidater.map((i) => i.ident) }
     }, [aktorId, isLoading, isError, identer])
 
     useEffect(() => {
         if (resultat.status === 'funnet') {
             onFunnet(resultat.fnr)
         }
+        // Reset aktorId etter funnet eller feil, men ikke ved flereFunnet (bruker må velge)
         if (resultat.status === 'funnet' || resultat.status === 'feil') {
             const timer = setTimeout(() => settAktorIdState(undefined), 0)
             return () => clearTimeout(timer)

--- a/src/utils/useAktorIdOppslag.ts
+++ b/src/utils/useAktorIdOppslag.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+
+import { useIdenter } from '../queryhooks/useIdenter'
+
+type AktorIdOppslagResultat =
+    | { status: 'inaktiv' }
+    | { status: 'laster' }
+    | { status: 'feil'; melding: string }
+    | { status: 'funnet'; fnr: string }
+
+export function useAktorIdOppslag(onFunnet: (fnr: string) => void): {
+    settAktorId: (aktorId: string | undefined) => void
+    resultat: AktorIdOppslagResultat
+} {
+    const [aktorId, settAktorIdState] = useState<string | undefined>()
+
+    const { data: identer, isLoading, isError } = useIdenter(aktorId, aktorId !== undefined)
+
+    const resultat = useMemo((): AktorIdOppslagResultat => {
+        if (aktorId === undefined) return { status: 'inaktiv' }
+        if (isLoading) return { status: 'laster' }
+        if (isError) return { status: 'feil', melding: 'Feil ved oppslag av aktørId' }
+        if (!identer) return { status: 'laster' }
+        const folkeregisterIdent = identer.find((i) => i.gruppe === 'FOLKEREGISTERIDENT')
+        if (folkeregisterIdent) return { status: 'funnet', fnr: folkeregisterIdent.ident }
+        return { status: 'feil', melding: 'Fant ikke fødselsnummer for oppgitt aktørId' }
+    }, [aktorId, isLoading, isError, identer])
+
+    useEffect(() => {
+        if (resultat.status === 'funnet') {
+            onFunnet(resultat.fnr)
+        }
+        if (resultat.status === 'funnet' || resultat.status === 'feil') {
+            const timer = setTimeout(() => settAktorIdState(undefined), 0)
+            return () => clearTimeout(timer)
+        }
+    }, [resultat, onFunnet])
+
+    const settAktorId = useCallback((nyAktorId: string | undefined) => {
+        settAktorIdState(nyAktorId)
+    }, [])
+
+    return { settAktorId, resultat }
+}


### PR DESCRIPTION
Lim inn en 13-sifret aktørId i søkefeltet på forsiden — fnr slås opp automatisk.

- Én aktiv ident: settes direkte
- Flere aktive identer: velg fra liste
- Historiske identer ignoreres når aktive finnes
- Søkefeltet beholder aktørId-en som ble søkt på, og viser funnet fnr under feltet
- Fiks race condition ved rask endring av søk