### PR TITLE
Tom søk laster testdata lokalt

### DIFF
--- a/src/components/FnrSokefelt.tsx
+++ b/src/components/FnrSokefelt.tsx
@@ -15,6 +15,7 @@ type Props = {
     label?: string
     description?: string
     valideringstype?: Valideringstype
+    erMockBackend?: boolean
 }
 
 const feilmeldinger: Record<Valideringstype, string> = {
@@ -35,6 +36,7 @@ const FnrSokefelt = ({
     label = 'Fødselsnummer',
     description,
     valideringstype = 'fnr',
+    erMockBackend = false,
 }: Props) => {
     const { fnr, settFnr, nullstillFnr } = useValgtFnr()
     const queryClient = useQueryClient()
@@ -83,6 +85,11 @@ const FnrSokefelt = ({
     }, [fnr])
 
     const handterSok = (input: string) => {
+        if (input === '' && erMockBackend) {
+            settFnr('12345678901')
+            return
+        }
+
         setSokeverdi(input)
 
         const validertVerdi = valideringsfunksjoner[valideringstype](input)

--- a/src/initialprops/initialProps.ts
+++ b/src/initialprops/initialProps.ts
@@ -1,17 +1,20 @@
 import { GetServerSidePropsResult } from 'next'
 
 import { beskyttetSide } from '../auth/beskyttetSide'
+import { isMockBackend } from '../utils/environment'
 
 export const initialProps = beskyttetSide(async (): Promise<GetServerSidePropsPrefetchResult> => {
     return {
         props: {
             tidspunkt: new Date().getDate(),
+            erMockBackend: isMockBackend(),
         },
     }
 })
 
 export interface PrefetchResults {
     tidspunkt: number
+    erMockBackend: boolean
 }
 
 export type GetServerSidePropsPrefetchResult = GetServerSidePropsResult<PrefetchResults>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 
 import FnrSokefelt from '../components/FnrSokefelt'
 import IdOppslagSokefelt from '../components/IdOppslagSokefelt'
-import { initialProps } from '../initialprops/initialProps'
+import { initialProps, PrefetchResults } from '../initialprops/initialProps'
 import { useSoknader } from '../queryhooks/useSoknader'
 import { useSykmeldinger } from '../queryhooks/useSykmeldinger'
 import TidslinjeKombinert from '../components/TidslinjeKombinert'
 import { useValgtFnr } from '../utils/useValgtFnr'
 
-const Index = () => {
+const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
     const { fnr } = useValgtFnr()
 
     const { data: soknadData } = useSoknader(fnr, fnr !== undefined)
@@ -24,6 +24,7 @@ const Index = () => {
                     label="Fødselsnummer eller aktørId"
                     description="11-sifret fnr eller 13-sifret aktørId"
                     valideringstype="fnrEllerAktorId"
+                    erMockBackend={erMockBackend}
                 />
                 <IdOppslagSokefelt />
             </div>


### PR DESCRIPTION
Når man kjører med mock-backend og klikker søk med tomt felt, lastes testdata direkte uten å måtte skrive inn fnr.