### PR TITLE
vis korrigerte klippede soknader

### DIFF
--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -7,6 +7,7 @@ import { useSoknadKafkaformat } from '../queryhooks/useSoknadKafkaformat'
 
 import { Detaljer } from './Detaljer'
 import { Filter } from './Filter'
+import { SammenlignDetaljer } from './SammenlignDetaljer'
 
 type VisModus = 'vanlig' | 'kafkaformat' | 'begge'
 
@@ -14,6 +15,7 @@ type DrawerVariant =
     | { type: 'sykmelding'; objekt: object; periodeInfo: React.ReactNode }
     | { type: 'soknad'; soknadId: string; objekt: object; periodeInfo: React.ReactNode }
     | { type: 'klippetSoknad'; objekt: object }
+    | { type: 'sammenlign'; objekt1: object; tittel1: string; objekt2: object; tittel2: string }
 
 export interface DrawerInnhold {
     tittel: string
@@ -68,6 +70,18 @@ export function lagKlippetSoknadDrawerInnhold(klippetSoknad: object): DrawerInnh
     return {
         tittel: 'Klippet søknad',
         variant: { type: 'klippetSoknad', objekt: klippetSoknad },
+    }
+}
+
+export function lagSammenlignDrawerInnhold(
+    objekt1: object,
+    tittel1: string,
+    objekt2: object,
+    tittel2: string,
+): DrawerInnhold {
+    return {
+        tittel: 'Sammenligning',
+        variant: { type: 'sammenlign', objekt1, tittel1, objekt2, tittel2 },
     }
 }
 
@@ -210,6 +224,15 @@ function DrawerInnholdRenderer({
             )
         case 'klippetSoknad':
             return <Detaljer objekt={variant.objekt} filter={filter} setFilter={setFilter} />
+        case 'sammenlign':
+            return (
+                <SammenlignDetaljer
+                    objekt1={variant.objekt1}
+                    tittel1={variant.tittel1}
+                    objekt2={variant.objekt2}
+                    tittel2={variant.tittel2}
+                />
+            )
     }
 }
 
@@ -234,6 +257,8 @@ export default function DetaljerDrawer({
 
     if (!mounted) return null
 
+    const erSammenlign = innhold?.variant.type === 'sammenlign'
+
     const posisjonKlasser = erBunn
         ? [
               'fixed bottom-0 left-0 z-[99999] flex h-1/2 w-full flex-col',
@@ -243,7 +268,7 @@ export default function DetaljerDrawer({
           ]
         : [
               'fixed top-0 right-0 z-[99999] flex h-full flex-col',
-              erSoknad && erBegge ? 'w-[900px]' : 'w-[500px]',
+              erSammenlign ? 'w-[900px]' : erSoknad && erBegge ? 'w-[900px]' : 'w-[500px]',
               'border-l border-gray-200 shadow-[-4px_0_24px_rgba(0,0,0,0.12)]',
               'transition-[transform,width] duration-300 ease-in-out',
               erApen ? 'translate-x-0' : 'translate-x-full',

--- a/src/components/DetaljerDrawer.tsx
+++ b/src/components/DetaljerDrawer.tsx
@@ -304,11 +304,11 @@ export default function DetaljerDrawer({
                             value={visModus}
                             onChange={(v) => setVisModus(v as VisModus)}
                             size="small"
-                            variant="neutral"
+                            data-color="neutral"
                         >
-                            <ToggleGroup.Item value="vanlig">Detaljer</ToggleGroup.Item>
-                            <ToggleGroup.Item value="kafkaformat">Kafka</ToggleGroup.Item>
-                            <ToggleGroup.Item value="begge">Begge</ToggleGroup.Item>
+                            <ToggleGroup.Item value="vanlig" label="Detaljer" />
+                            <ToggleGroup.Item value="kafkaformat" label="Kafka" />
+                            <ToggleGroup.Item value="begge" label="Begge" />
                         </ToggleGroup>
                     )}
                     <Button

--- a/src/components/SammenlignDetaljer.tsx
+++ b/src/components/SammenlignDetaljer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { ToggleGroup } from '@navikt/ds-react'
+import { Table, ToggleGroup, VStack, HStack } from '@navikt/ds-react'
 
 import { sammenlignObjekter, SammenlignRad } from '../utils/sammenlignUtils'
 
@@ -12,15 +12,15 @@ interface Props {
 
 const radBakgrunn = (rad: SammenlignRad): string => {
     if (rad.verdi1 === undefined || rad.verdi2 === undefined) {
-        return 'bg-surface-neutral-subtle'
+        return 'bg-ax-bg-neutral-soft'
     }
-    if (!rad.erLik) return 'bg-surface-warning-subtle'
+    if (!rad.erLik) return 'bg-ax-bg-warning-soft'
     return ''
 }
 
 const VerdiCelle = ({ verdi }: { verdi: string | undefined }) => {
     if (verdi === undefined) {
-        return <span className="text-text-subtle italic">—</span>
+        return <span className="text-ax-text-neutral-subtle italic">—</span>
     }
     return <span className="break-all">{verdi}</span>
 }
@@ -34,50 +34,60 @@ export const SammenlignDetaljer = ({ tittel1, tittel2, objekt1, objekt2 }: Props
     const antallForskjeller = rader.filter((r) => !r.erLik).length
 
     return (
-        <div className="space-y-3">
-            <div className="flex items-center gap-3">
+        <VStack gap="space-12">
+            <HStack align="center" gap="space-12">
                 <ToggleGroup
                     value={kunForskjeller}
                     onChange={(v) => setKunForskjeller(v as 'alle' | 'forskjeller')}
                     size="small"
-                    variant="neutral"
+                    data-color="neutral"
+                    aria-label="Velg hvilke felt som vises"
                 >
-                    <ToggleGroup.Item value="forskjeller">Kun forskjeller ({antallForskjeller})</ToggleGroup.Item>
-                    <ToggleGroup.Item value="alle">Alle felt ({rader.length})</ToggleGroup.Item>
+                    <ToggleGroup.Item value="forskjeller" label={`Kun forskjeller (${antallForskjeller})`} />
+                    <ToggleGroup.Item value="alle" label={`Alle felt (${rader.length})`} />
                 </ToggleGroup>
-            </div>
+            </HStack>
 
-            <div className="overflow-x-auto">
-                <table className="w-full text-sm border-collapse">
-                    <thead>
-                        <tr className="border-b border-gray-200">
-                            <th className="text-left py-1.5 pr-3 font-semibold text-gray-500 w-[35%]">Felt</th>
-                            <th className="text-left py-1.5 pr-3 font-semibold w-[32.5%]">{tittel1}</th>
-                            <th className="text-left py-1.5 font-semibold w-[32.5%]">{tittel2}</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                        {filtrertRader.map((rad) => (
-                            <tr key={rad.nøkkel} className={radBakgrunn(rad)}>
-                                <td className="py-1 pr-3 text-gray-500 font-mono text-xs align-top">{rad.nøkkel}</td>
-                                <td className="py-1 pr-3 align-top">
-                                    <VerdiCelle verdi={rad.verdi1} />
-                                </td>
-                                <td className="py-1 align-top">
-                                    <VerdiCelle verdi={rad.verdi2} />
-                                </td>
-                            </tr>
-                        ))}
-                        {filtrertRader.length === 0 && (
-                            <tr>
-                                <td colSpan={3} className="py-4 text-center text-text-subtle italic">
-                                    Ingen forskjeller funnet
-                                </td>
-                            </tr>
-                        )}
-                    </tbody>
-                </table>
-            </div>
-        </div>
+            <Table size="small">
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col" className="w-[35%] text-ax-text-neutral-subtle">
+                            Felt
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col" className="w-[32.5%]">
+                            {tittel1}
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col" className="w-[32.5%]">
+                            {tittel2}
+                        </Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {filtrertRader.map((rad) => (
+                        <Table.Row key={rad.nøkkel} className={radBakgrunn(rad)}>
+                            <Table.HeaderCell
+                                scope="row"
+                                className="font-mono text-xs align-top text-ax-text-neutral-subtle"
+                            >
+                                {rad.nøkkel}
+                            </Table.HeaderCell>
+                            <Table.DataCell className="align-top">
+                                <VerdiCelle verdi={rad.verdi1} />
+                            </Table.DataCell>
+                            <Table.DataCell className="align-top">
+                                <VerdiCelle verdi={rad.verdi2} />
+                            </Table.DataCell>
+                        </Table.Row>
+                    ))}
+                    {filtrertRader.length === 0 && (
+                        <Table.Row>
+                            <Table.DataCell colSpan={3} className="text-center text-ax-text-neutral-subtle italic">
+                                Ingen forskjeller funnet
+                            </Table.DataCell>
+                        </Table.Row>
+                    )}
+                </Table.Body>
+            </Table>
+        </VStack>
     )
 }

--- a/src/components/SammenlignDetaljer.tsx
+++ b/src/components/SammenlignDetaljer.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { ToggleGroup } from '@navikt/ds-react'
+
+import { sammenlignObjekter, SammenlignRad } from '../utils/sammenlignUtils'
+
+interface Props {
+    tittel1: string
+    tittel2: string
+    objekt1: object
+    objekt2: object
+}
+
+const radBakgrunn = (rad: SammenlignRad): string => {
+    if (rad.verdi1 === undefined || rad.verdi2 === undefined) {
+        return 'bg-surface-neutral-subtle'
+    }
+    if (!rad.erLik) return 'bg-surface-warning-subtle'
+    return ''
+}
+
+const VerdiCelle = ({ verdi }: { verdi: string | undefined }) => {
+    if (verdi === undefined) {
+        return <span className="text-text-subtle italic">—</span>
+    }
+    return <span className="break-all">{verdi}</span>
+}
+
+export const SammenlignDetaljer = ({ tittel1, tittel2, objekt1, objekt2 }: Props) => {
+    const [kunForskjeller, setKunForskjeller] = useState<'alle' | 'forskjeller'>('forskjeller')
+
+    const rader = sammenlignObjekter(objekt1, objekt2)
+    const filtrertRader = kunForskjeller === 'forskjeller' ? rader.filter((r) => !r.erLik) : rader
+
+    const antallForskjeller = rader.filter((r) => !r.erLik).length
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center gap-3">
+                <ToggleGroup
+                    value={kunForskjeller}
+                    onChange={(v) => setKunForskjeller(v as 'alle' | 'forskjeller')}
+                    size="small"
+                    variant="neutral"
+                >
+                    <ToggleGroup.Item value="forskjeller">Kun forskjeller ({antallForskjeller})</ToggleGroup.Item>
+                    <ToggleGroup.Item value="alle">Alle felt ({rader.length})</ToggleGroup.Item>
+                </ToggleGroup>
+            </div>
+
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm border-collapse">
+                    <thead>
+                        <tr className="border-b border-gray-200">
+                            <th className="text-left py-1.5 pr-3 font-semibold text-gray-500 w-[35%]">Felt</th>
+                            <th className="text-left py-1.5 pr-3 font-semibold w-[32.5%]">{tittel1}</th>
+                            <th className="text-left py-1.5 font-semibold w-[32.5%]">{tittel2}</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                        {filtrertRader.map((rad) => (
+                            <tr key={rad.nøkkel} className={radBakgrunn(rad)}>
+                                <td className="py-1 pr-3 text-gray-500 font-mono text-xs align-top">{rad.nøkkel}</td>
+                                <td className="py-1 pr-3 align-top">
+                                    <VerdiCelle verdi={rad.verdi1} />
+                                </td>
+                                <td className="py-1 align-top">
+                                    <VerdiCelle verdi={rad.verdi2} />
+                                </td>
+                            </tr>
+                        ))}
+                        {filtrertRader.length === 0 && (
+                            <tr>
+                                <td colSpan={3} className="py-4 text-center text-text-subtle italic">
+                                    Ingen forskjeller funnet
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -24,6 +24,7 @@ interface Props {
     klipp: KlippetSykepengesoknadRecord[]
     sammenlignModus?: boolean
     onSammenlignAvslutt?: () => void
+    onSammenlignValgteEndret?: (titler: string[]) => void
 }
 
 const TidslinjeKombinert = ({
@@ -32,6 +33,7 @@ const TidslinjeKombinert = ({
     klipp,
     sammenlignModus: sammenlignModusProp,
     onSammenlignAvslutt,
+    onSammenlignValgteEndret,
 }: Props): React.ReactElement => {
     const {
         filter,
@@ -58,7 +60,14 @@ const TidslinjeKombinert = ({
         handleStartSammenlign,
         handleAvsluttSammenlign,
         handleLukkSammenlignDrawer,
-    } = useTidslinjeKombinert(sykmeldinger, soknader, klipp, sammenlignModusProp, onSammenlignAvslutt)
+    } = useTidslinjeKombinert(
+        sykmeldinger,
+        soknader,
+        klipp,
+        sammenlignModusProp,
+        onSammenlignAvslutt,
+        onSammenlignValgteEndret,
+    )
 
     const { valgtPeriodeId, valgtDrawerKildeId, oppslagData, nullstillValgtPeriode } = useValgtFnr()
 

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
-import { BodyShort } from '@navikt/ds-react'
+import { BodyShort, Button, HStack } from '@navikt/ds-react'
+import { ArrowsSquarepathIcon } from '@navikt/aksel-icons'
 import dayjs from 'dayjs'
 
 import { BackendSoknad, KlippetSykepengesoknadRecord, Soknad, dayjsToDate } from '../queryhooks/useSoknader'
@@ -43,6 +44,11 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         handlePeriodeValgt,
         handleDrawerValgt,
         handleLukkDrawer,
+        sammenlignModus,
+        setSammenlignModus,
+        sammenlignValgte,
+        handleSammenlignValgt,
+        handleAvsluttSammenlign,
     } = useTidslinjeKombinert(sykmeldinger, soknader, klipp)
 
     const { valgtPeriodeId, valgtDrawerKildeId, oppslagData, nullstillValgtPeriode } = useValgtFnr()
@@ -99,10 +105,39 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         setVisningstilDato,
     ])
 
+    const sammenlignStatusTekst = () => {
+        if (sammenlignValgte.length === 0) return 'Velg første element'
+        if (sammenlignValgte.length === 1) return `Valgt: ${sammenlignValgte[0].tittel} — velg ett til`
+        return `Sammenligner: ${sammenlignValgte[0].tittel} vs ${sammenlignValgte[1].tittel}`
+    }
+
+    const sammenlignValgteIder = sammenlignValgte.map((e) => e.kildeId)
+
     return (
         <div className="min-w-[800px] min-h-[2000px] overflow-x-auto">
             <ValgteFilter filter={filter} setFilter={setFilter} />
-            <BodyShort className="font-semibold">{`${sykmeldingAntall} sykmelding(er) · ${soknadAntall} søknad(er)`}</BodyShort>
+            <HStack align="center" gap="space-4" className="mb-1">
+                <BodyShort className="font-semibold">{`${sykmeldingAntall} sykmelding(er) · ${soknadAntall} søknad(er)`}</BodyShort>
+                {!sammenlignModus ? (
+                    <Button
+                        size="small"
+                        variant="secondary"
+                        icon={<ArrowsSquarepathIcon aria-hidden />}
+                        onClick={() => setSammenlignModus(true)}
+                    >
+                        Sammenlign
+                    </Button>
+                ) : (
+                    <HStack align="center" gap="space-2">
+                        <BodyShort size="small" className="text-text-subtle italic">
+                            {sammenlignStatusTekst()}
+                        </BodyShort>
+                        <Button size="small" variant="tertiary-neutral" onClick={handleAvsluttSammenlign}>
+                            Avslutt sammenligning
+                        </Button>
+                    </HStack>
+                )}
+            </HStack>
             <VelgZoomPeriode
                 setFraDato={setVisningsFraDato}
                 setTilDato={setVisningstilDato}
@@ -116,6 +151,9 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                         aktivPeriodeId={aktivPeriodeId}
                         aktivDrawerKildeId={aktivDrawerKildeId}
                         onPeriodeValgt={handlePeriodeValgt}
+                        sammenlignModus={sammenlignModus}
+                        sammenlignValgteIder={sammenlignValgteIder}
+                        onSammenlignValgt={handleSammenlignValgt}
                     />
                     <SoknadTidslinje
                         soknaderGruppert={soknaderGruppert}
@@ -124,6 +162,9 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                         aktivDrawerKildeId={aktivDrawerKildeId}
                         onPeriodeValgt={handlePeriodeValgt}
                         onDrawerValgt={handleDrawerValgt}
+                        sammenlignModus={sammenlignModus}
+                        sammenlignValgteIder={sammenlignValgteIder}
+                        onSammenlignValgt={handleSammenlignValgt}
                     />
                 </>
             )}
@@ -133,7 +174,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                 setFilter={setFilter}
                 plassering={drawerPlassering}
                 setPlassering={setDrawerPlassering}
-                onLukk={handleLukkDrawer}
+                onLukk={sammenlignModus ? handleAvsluttSammenlign : handleLukkDrawer}
             />
         </div>
     )

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -129,7 +129,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                     </Button>
                 ) : (
                     <HStack align="center" gap="space-2">
-                        <BodyShort size="small" className="text-text-subtle italic">
+                        <BodyShort size="small" className="text-text-subtle italic" aria-live="polite" aria-atomic="true">
                             {sammenlignStatusTekst()}
                         </BodyShort>
                         <Button size="small" variant="tertiary-neutral" onClick={handleAvsluttSammenlign}>

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -45,10 +45,11 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         handleDrawerValgt,
         handleLukkDrawer,
         sammenlignModus,
-        setSammenlignModus,
         sammenlignValgte,
         handleSammenlignValgt,
+        handleStartSammenlign,
         handleAvsluttSammenlign,
+        handleLukkSammenlignDrawer,
     } = useTidslinjeKombinert(sykmeldinger, soknader, klipp)
 
     const { valgtPeriodeId, valgtDrawerKildeId, oppslagData, nullstillValgtPeriode } = useValgtFnr()
@@ -123,20 +124,25 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                         size="small"
                         variant="secondary"
                         icon={<ArrowsSquarepathIcon aria-hidden />}
-                        onClick={() => setSammenlignModus(true)}
+                        onClick={handleStartSammenlign}
                     >
                         Sammenlign
                     </Button>
                 ) : (
                     <HStack align="center" gap="space-2">
-                        <BodyShort size="small" className="text-text-subtle italic" aria-live="polite" aria-atomic="true">
-                            {sammenlignStatusTekst()}
-                        </BodyShort>
                         <Button size="small" variant="tertiary-neutral" onClick={handleAvsluttSammenlign}>
                             Avslutt sammenligning
                         </Button>
                     </HStack>
                 )}
+                <BodyShort
+                    size="small"
+                    className="text-ax-text-neutral-subtle italic"
+                    aria-live="polite"
+                    aria-atomic="true"
+                >
+                    {sammenlignModus ? sammenlignStatusTekst() : ''}
+                </BodyShort>
             </HStack>
             <VelgZoomPeriode
                 setFraDato={setVisningsFraDato}
@@ -174,7 +180,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                 setFilter={setFilter}
                 plassering={drawerPlassering}
                 setPlassering={setDrawerPlassering}
-                onLukk={sammenlignModus ? handleAvsluttSammenlign : handleLukkDrawer}
+                onLukk={sammenlignModus ? handleLukkSammenlignDrawer : handleLukkDrawer}
             />
         </div>
     )

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -22,9 +22,17 @@ interface Props {
     sykmeldinger: Sykmelding[]
     soknader: Soknad[]
     klipp: KlippetSykepengesoknadRecord[]
+    sammenlignModus?: boolean
+    onSammenlignAvslutt?: () => void
 }
 
-const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.ReactElement => {
+const TidslinjeKombinert = ({
+    sykmeldinger,
+    soknader,
+    klipp,
+    sammenlignModus: sammenlignModusProp,
+    onSammenlignAvslutt,
+}: Props): React.ReactElement => {
     const {
         filter,
         setFilter,
@@ -50,7 +58,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
         handleStartSammenlign,
         handleAvsluttSammenlign,
         handleLukkSammenlignDrawer,
-    } = useTidslinjeKombinert(sykmeldinger, soknader, klipp)
+    } = useTidslinjeKombinert(sykmeldinger, soknader, klipp, sammenlignModusProp, onSammenlignAvslutt)
 
     const { valgtPeriodeId, valgtDrawerKildeId, oppslagData, nullstillValgtPeriode } = useValgtFnr()
 
@@ -119,7 +127,7 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
             <ValgteFilter filter={filter} setFilter={setFilter} />
             <HStack align="center" gap="space-4" className="mb-1">
                 <BodyShort className="font-semibold">{`${sykmeldingAntall} sykmelding(er) · ${soknadAntall} søknad(er)`}</BodyShort>
-                {!sammenlignModus ? (
+                {sammenlignModusProp === undefined && !sammenlignModus && (
                     <Button
                         size="small"
                         variant="secondary"
@@ -128,12 +136,11 @@ const TidslinjeKombinert = ({ sykmeldinger, soknader, klipp }: Props): React.Rea
                     >
                         Sammenlign
                     </Button>
-                ) : (
-                    <HStack align="center" gap="space-2">
-                        <Button size="small" variant="tertiary-neutral" onClick={handleAvsluttSammenlign}>
-                            Avslutt sammenligning
-                        </Button>
-                    </HStack>
+                )}
+                {sammenlignModusProp === undefined && sammenlignModus && (
+                    <Button size="small" variant="tertiary-neutral" onClick={handleAvsluttSammenlign}>
+                        Avslutt sammenligning
+                    </Button>
                 )}
                 <BodyShort
                     size="small"

--- a/src/components/TidslinjeKombinert.tsx
+++ b/src/components/TidslinjeKombinert.tsx
@@ -151,14 +151,16 @@ const TidslinjeKombinert = ({
                         Avslutt sammenligning
                     </Button>
                 )}
-                <BodyShort
-                    size="small"
-                    className="text-ax-text-neutral-subtle italic"
-                    aria-live="polite"
-                    aria-atomic="true"
-                >
-                    {sammenlignModus ? sammenlignStatusTekst() : ''}
-                </BodyShort>
+                {sammenlignModusProp === undefined && (
+                    <BodyShort
+                        size="small"
+                        className="text-ax-text-neutral-subtle italic"
+                        aria-live="polite"
+                        aria-atomic="true"
+                    >
+                        {sammenlignModus ? sammenlignStatusTekst() : ''}
+                    </BodyShort>
+                )}
             </HStack>
             <VelgZoomPeriode
                 setFraDato={setVisningsFraDato}

--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -11,6 +11,7 @@ import { arbeidsgiverLabelForSoknader } from '../../utils/soknadArbeidsgiverLabe
 import { lagKlippetSoknadDrawerInnhold, lagSoknadDrawerInnhold } from '../DetaljerDrawer'
 import ViktigeFeltForSoknad from '../periodeinfo/ViktigeFeltForSoknad'
 import { timelinePeriodeStatus } from '../soknad/Tidslinje'
+import type { SammenlignElement } from './useTidslinjeKombinert'
 
 import type { OnPeriodeValgt } from './SykmeldingRader'
 
@@ -20,6 +21,9 @@ interface Props {
     aktivPeriodeId: string | null
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
+    sammenlignModus?: boolean
+    sammenlignValgteIder?: string[]
+    onSammenlignValgt?: (element: SammenlignElement) => void
 }
 
 export const lagSoknadRader = ({
@@ -28,6 +32,9 @@ export const lagSoknadRader = ({
     aktivPeriodeId,
     aktivDrawerKildeId,
     onPeriodeValgt,
+    sammenlignModus = false,
+    sammenlignValgteIder = [],
+    onSammenlignValgt,
 }: Props): React.ReactElement[] => {
     return sorterSoknadGrupperEtterSignaturDato(Array.from(soknaderGruppert.entries())).flatMap(([arbId, arb]) => {
         if (arbId === 'opphold_utland') return []
@@ -87,6 +94,11 @@ export const lagSoknadRader = ({
                             const erAktiv = aktivPeriodeId !== null && aktivPeriodeId === sykmeldingId
                             const kildeId = sok.soknad.id
                             const erValgtPeriode = aktivDrawerKildeId === kildeId
+                            const erSammenlignValgt = sammenlignValgteIder.includes(kildeId)
+
+                            const fomStr = sok.soknad.fom ? sok.soknad.fom.format('D MMM YYYY') : ''
+                            const tomStr = sok.soknad.tom ? sok.soknad.tom.format('D MMM YYYY') : ''
+
                             klippingAvSoknad.push(
                                 <Timeline.Period
                                     start={sokFom}
@@ -95,9 +107,23 @@ export const lagSoknadRader = ({
                                     icon={ikonerForSoknad(sok.soknad)}
                                     key={sok.soknad.tom?.toISOString() ?? sok.soknad.id}
                                     isActive={erAktiv}
-                                    className={erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : undefined}
+                                    className={
+                                        sammenlignModus
+                                            ? erSammenlignValgt
+                                                ? 'shadow-[inset_0_0_0_4px_#0067c5]!'
+                                                : undefined
+                                            : erValgtPeriode
+                                              ? 'shadow-[inset_0_0_0_4px_#dc2626]!'
+                                              : undefined
+                                    }
                                     onSelectPeriod={() => {
-                                        if (aktivDrawerKildeId === kildeId) {
+                                        if (sammenlignModus) {
+                                            onSammenlignValgt?.({
+                                                kildeId,
+                                                objekt: sok.soknad,
+                                                tittel: `Søknad ${fomStr}–${tomStr}`,
+                                            })
+                                        } else if (aktivDrawerKildeId === kildeId) {
                                             onPeriodeValgt(null, null, null)
                                         } else {
                                             onPeriodeValgt(

--- a/src/components/kombinert/SoknadRader.tsx
+++ b/src/components/kombinert/SoknadRader.tsx
@@ -11,8 +11,8 @@ import { arbeidsgiverLabelForSoknader } from '../../utils/soknadArbeidsgiverLabe
 import { lagKlippetSoknadDrawerInnhold, lagSoknadDrawerInnhold } from '../DetaljerDrawer'
 import ViktigeFeltForSoknad from '../periodeinfo/ViktigeFeltForSoknad'
 import { timelinePeriodeStatus } from '../soknad/Tidslinje'
-import type { SammenlignElement } from './useTidslinjeKombinert'
 
+import type { SammenlignElement } from './useTidslinjeKombinert'
 import type { OnPeriodeValgt } from './SykmeldingRader'
 
 interface Props {

--- a/src/components/kombinert/SoknadTidslinje.tsx
+++ b/src/components/kombinert/SoknadTidslinje.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import { BodyShort, Box, Timeline } from '@navikt/ds-react'
 
 import type { ArbeidsgiverGruppering } from '../../utils/gruppering'
+import type { SammenlignElement } from './useTidslinjeKombinert'
 
 import { lagOppholdUtlandPins, type OnDrawerValgt } from './OppholdUtlandPins'
 import { lagSoknadRader } from './SoknadRader'
@@ -15,6 +16,9 @@ interface Props {
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
     onDrawerValgt: OnDrawerValgt
+    sammenlignModus: boolean
+    sammenlignValgteIder: string[]
+    onSammenlignValgt: (element: SammenlignElement) => void
 }
 
 const SoknadTidslinje = ({
@@ -24,6 +28,9 @@ const SoknadTidslinje = ({
     aktivDrawerKildeId,
     onPeriodeValgt,
     onDrawerValgt,
+    sammenlignModus,
+    sammenlignValgteIder,
+    onSammenlignValgt,
 }: Props): React.ReactElement => {
     return (
         <Box
@@ -45,6 +52,9 @@ const SoknadTidslinje = ({
                     aktivPeriodeId,
                     aktivDrawerKildeId,
                     onPeriodeValgt,
+                    sammenlignModus,
+                    sammenlignValgteIder,
+                    onSammenlignValgt,
                 })}
                 {lagOppholdUtlandPins({
                     soknaderGruppert,

--- a/src/components/kombinert/SoknadTidslinje.tsx
+++ b/src/components/kombinert/SoknadTidslinje.tsx
@@ -3,8 +3,8 @@ import dayjs from 'dayjs'
 import { BodyShort, Box, Timeline } from '@navikt/ds-react'
 
 import type { ArbeidsgiverGruppering } from '../../utils/gruppering'
-import type { SammenlignElement } from './useTidslinjeKombinert'
 
+import type { SammenlignElement } from './useTidslinjeKombinert'
 import { lagOppholdUtlandPins, type OnDrawerValgt } from './OppholdUtlandPins'
 import { lagSoknadRader } from './SoknadRader'
 import type { OnPeriodeValgt } from './SykmeldingRader'
@@ -16,9 +16,9 @@ interface Props {
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
     onDrawerValgt: OnDrawerValgt
-    sammenlignModus: boolean
-    sammenlignValgteIder: string[]
-    onSammenlignValgt: (element: SammenlignElement) => void
+    sammenlignModus?: boolean
+    sammenlignValgteIder?: string[]
+    onSammenlignValgt?: (element: SammenlignElement) => void
 }
 
 const SoknadTidslinje = ({
@@ -28,8 +28,8 @@ const SoknadTidslinje = ({
     aktivDrawerKildeId,
     onPeriodeValgt,
     onDrawerValgt,
-    sammenlignModus,
-    sammenlignValgteIder,
+    sammenlignModus = false,
+    sammenlignValgteIder = [],
     onSammenlignValgt,
 }: Props): React.ReactElement => {
     return (

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -14,6 +14,7 @@ import {
     sykmeldingStatus,
     SykmeldingerPerArbeidsgiver,
 } from '../sykmelding/sykmeldingTidslinjeUtils'
+
 import type { SammenlignElement } from './useTidslinjeKombinert'
 
 export type OnPeriodeValgt = (periodeId: string | null, kildeId: string | null, drawer: DrawerInnhold | null) => void

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -14,6 +14,7 @@ import {
     sykmeldingStatus,
     SykmeldingerPerArbeidsgiver,
 } from '../sykmelding/sykmeldingTidslinjeUtils'
+import type { SammenlignElement } from './useTidslinjeKombinert'
 
 export type OnPeriodeValgt = (periodeId: string | null, kildeId: string | null, drawer: DrawerInnhold | null) => void
 
@@ -23,6 +24,9 @@ interface Props {
     aktivPeriodeId: string | null
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
+    sammenlignModus?: boolean
+    sammenlignValgteIder?: string[]
+    onSammenlignValgt?: (element: SammenlignElement) => void
 }
 
 export const lagSykmeldingRader = ({
@@ -31,6 +35,9 @@ export const lagSykmeldingRader = ({
     aktivPeriodeId,
     aktivDrawerKildeId,
     onPeriodeValgt,
+    sammenlignModus = false,
+    sammenlignValgteIder = [],
+    onSammenlignValgt,
 }: Props): React.ReactElement[] => {
     return sorterSykmeldingGrupperEtterSignaturDato(Array.from(sykmeldingerGruppertPaArbeidsgiver.entries())).flatMap(
         ([arbeidsgiverId, arbeidsgiver]) => {
@@ -63,6 +70,12 @@ export const lagSykmeldingRader = ({
                 const ikonHeader = ikonParForSykmeldingPerioder(perioder.length, forstePeriodetype, arbeidssituasjon)
 
                 const erValgtPeriode = aktivDrawerKildeId === sykmeldingAktivId
+                const erSammenlignValgt = sammenlignValgteIder.includes(sykmeldingAktivId)
+
+                const sammenlignKantKlasse = erSammenlignValgt ? 'shadow-[inset_0_0_0_4px_#0067c5]!' : undefined
+                const normalKantKlasse = erValgtPeriode
+                    ? 'shadow-[inset_0_0_0_4px_#dc2626]!'
+                    : 'ring-1 ring-inset ring-white/95'
 
                 return [
                     <Timeline.Period
@@ -70,13 +83,17 @@ export const lagSykmeldingRader = ({
                         end={sistePeriode.sluttDato}
                         status={status}
                         icon={ikon}
-                        className={
-                            erValgtPeriode ? 'shadow-[inset_0_0_0_4px_#dc2626]!' : 'ring-1 ring-inset ring-white/95'
-                        }
+                        className={sammenlignModus ? sammenlignKantKlasse : normalKantKlasse}
                         key={periodeKey}
                         isActive={aktivPeriodeId === sykmeldingAktivId}
                         onSelectPeriod={() => {
-                            if (aktivDrawerKildeId === sykmeldingAktivId) {
+                            if (sammenlignModus) {
+                                onSammenlignValgt?.({
+                                    kildeId: sykmeldingAktivId,
+                                    objekt: sykmelding,
+                                    tittel: `Sykmelding ${forstePeriode.fom}–${sistePeriode.tom}`,
+                                })
+                            } else if (aktivDrawerKildeId === sykmeldingAktivId) {
                                 onPeriodeValgt(null, null, null)
                             } else {
                                 onPeriodeValgt(

--- a/src/components/kombinert/SykmeldingRader.tsx
+++ b/src/components/kombinert/SykmeldingRader.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import dayjs from 'dayjs'
 import { StethoscopeIcon } from '@navikt/aksel-icons'
 import { Timeline } from '@navikt/ds-react'
 
@@ -89,10 +90,12 @@ export const lagSykmeldingRader = ({
                         isActive={aktivPeriodeId === sykmeldingAktivId}
                         onSelectPeriod={() => {
                             if (sammenlignModus) {
+                                const fomStr = dayjs(forstePeriode.fom).format('D MMM YYYY')
+                                const tomStr = dayjs(sistePeriode.tom).format('D MMM YYYY')
                                 onSammenlignValgt?.({
                                     kildeId: sykmeldingAktivId,
                                     objekt: sykmelding,
-                                    tittel: `Sykmelding ${forstePeriode.fom}–${sistePeriode.tom}`,
+                                    tittel: `Sykmelding ${fomStr}–${tomStr}`,
                                 })
                             } else if (aktivDrawerKildeId === sykmeldingAktivId) {
                                 onPeriodeValgt(null, null, null)

--- a/src/components/kombinert/SykmeldingTidslinje.tsx
+++ b/src/components/kombinert/SykmeldingTidslinje.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import { BodyShort, Box, Timeline } from '@navikt/ds-react'
 
 import type { SykmeldingerPerArbeidsgiver } from '../sykmelding/sykmeldingTidslinjeUtils'
+import type { SammenlignElement } from './useTidslinjeKombinert'
 
 import { lagSykmeldingRader, type OnPeriodeValgt } from './SykmeldingRader'
 
@@ -12,6 +13,9 @@ interface Props {
     aktivPeriodeId: string | null
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
+    sammenlignModus: boolean
+    sammenlignValgteIder: string[]
+    onSammenlignValgt: (element: SammenlignElement) => void
 }
 
 const SykmeldingTidslinje = ({
@@ -20,6 +24,9 @@ const SykmeldingTidslinje = ({
     aktivPeriodeId,
     aktivDrawerKildeId,
     onPeriodeValgt,
+    sammenlignModus,
+    sammenlignValgteIder,
+    onSammenlignValgt,
 }: Props): React.ReactElement => {
     return (
         <Box
@@ -41,6 +48,9 @@ const SykmeldingTidslinje = ({
                     aktivPeriodeId,
                     aktivDrawerKildeId,
                     onPeriodeValgt,
+                    sammenlignModus,
+                    sammenlignValgteIder,
+                    onSammenlignValgt,
                 })}
                 {!dayjs().isAfter(dayjs(aktivTidsvindu.til), 'day') && (
                     <Timeline.Pin date={dayjs().startOf('day').toDate()} data-idag="true">

--- a/src/components/kombinert/SykmeldingTidslinje.tsx
+++ b/src/components/kombinert/SykmeldingTidslinje.tsx
@@ -3,8 +3,8 @@ import dayjs from 'dayjs'
 import { BodyShort, Box, Timeline } from '@navikt/ds-react'
 
 import type { SykmeldingerPerArbeidsgiver } from '../sykmelding/sykmeldingTidslinjeUtils'
-import type { SammenlignElement } from './useTidslinjeKombinert'
 
+import type { SammenlignElement } from './useTidslinjeKombinert'
 import { lagSykmeldingRader, type OnPeriodeValgt } from './SykmeldingRader'
 
 interface Props {
@@ -13,9 +13,9 @@ interface Props {
     aktivPeriodeId: string | null
     aktivDrawerKildeId: string | null
     onPeriodeValgt: OnPeriodeValgt
-    sammenlignModus: boolean
-    sammenlignValgteIder: string[]
-    onSammenlignValgt: (element: SammenlignElement) => void
+    sammenlignModus?: boolean
+    sammenlignValgteIder?: string[]
+    onSammenlignValgt?: (element: SammenlignElement) => void
 }
 
 const SykmeldingTidslinje = ({
@@ -24,8 +24,8 @@ const SykmeldingTidslinje = ({
     aktivPeriodeId,
     aktivDrawerKildeId,
     onPeriodeValgt,
-    sammenlignModus,
-    sammenlignValgteIder,
+    sammenlignModus = false,
+    sammenlignValgteIder = [],
     onSammenlignValgt,
 }: Props): React.ReactElement => {
     return (

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -25,6 +25,8 @@ export const useTidslinjeKombinert = (
     sykmeldinger: Sykmelding[],
     soknader: Soknad[],
     klipp: KlippetSykepengesoknadRecord[],
+    eksternSammenlignModus?: boolean,
+    onEksternSammenlignAvslutt?: () => void,
 ) => {
     const [filter, setFilter] = useState<Filter[]>([])
     const [visningsFraDato, setVisningsFraDato] = useState<Date | null>(null)
@@ -33,7 +35,8 @@ export const useTidslinjeKombinert = (
     const [aktivDrawerKildeId, setAktivDrawerKildeId] = useState<string | null>(null)
     const [drawerInnhold, setDrawerInnhold] = useState<DrawerInnhold | null>(null)
     const [drawerPlassering, setDrawerPlassering] = useState<'bunn' | 'hoyre'>('hoyre')
-    const [sammenlignModus, setSammenlignModus] = useState(false)
+    const [internSammenlignModus, setInternSammenlignModus] = useState(false)
+    const sammenlignModus = eksternSammenlignModus ?? internSammenlignModus
     const [sammenlignValgte, setSammenlignValgte] = useState<SammenlignElement[]>([])
 
     const gyldigeSykmeldinger = validerSykmeldingsDatoer(sykmeldinger)
@@ -144,13 +147,17 @@ export const useTidslinjeKombinert = (
     }, [])
 
     const handleAvsluttSammenlign = useCallback(() => {
-        setSammenlignModus(false)
+        if (onEksternSammenlignAvslutt) {
+            onEksternSammenlignAvslutt()
+        } else {
+            setInternSammenlignModus(false)
+        }
         setSammenlignValgte([])
         setDrawerInnhold(null)
-    }, [])
+    }, [onEksternSammenlignAvslutt])
 
     const handleStartSammenlign = useCallback(() => {
-        setSammenlignModus(true)
+        setInternSammenlignModus(true)
     }, [])
 
     const handleLukkSammenlignDrawer = useCallback(() => {

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -149,6 +149,16 @@ export const useTidslinjeKombinert = (
         setDrawerInnhold(null)
     }, [])
 
+    const handleStartSammenlign = useCallback(() => {
+        setSammenlignModus(true)
+    }, [])
+
+    const handleLukkSammenlignDrawer = useCallback(() => {
+        setSammenlignValgte([])
+        setDrawerInnhold(null)
+        // sammenlignModus forblir true — brukeren kan velge nye elementer
+    }, [])
+
     return {
         filter,
         setFilter,
@@ -169,9 +179,10 @@ export const useTidslinjeKombinert = (
         handleDrawerValgt,
         handleLukkDrawer,
         sammenlignModus,
-        setSammenlignModus,
         sammenlignValgte,
         handleSammenlignValgt,
+        handleStartSammenlign,
         handleAvsluttSammenlign,
+        handleLukkSammenlignDrawer,
     }
 }

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -7,12 +7,19 @@ import gruppertOgFiltrert from '../../utils/gruppering'
 import { hentDatospenn, validerSykmeldingsDatoer } from '../../utils/sykmeldingValidering'
 import { beregnAktivTidsvindu, erPeriodeInnenforTidsvindu } from '../../utils/tidslinjeUtils'
 import type { DrawerInnhold } from '../DetaljerDrawer'
+import { lagSammenlignDrawerInnhold } from '../DetaljerDrawer'
 import type { Filter } from '../Filter'
 import {
     grupperSykmeldingerPaArbeidsgiver,
     perioderMedDatoer,
     sorterPerioder,
 } from '../sykmelding/sykmeldingTidslinjeUtils'
+
+export interface SammenlignElement {
+    kildeId: string
+    objekt: object
+    tittel: string
+}
 
 export const useTidslinjeKombinert = (
     sykmeldinger: Sykmelding[],
@@ -25,7 +32,9 @@ export const useTidslinjeKombinert = (
     const [aktivPeriodeId, setAktivPeriodeId] = useState<string | null>(null)
     const [aktivDrawerKildeId, setAktivDrawerKildeId] = useState<string | null>(null)
     const [drawerInnhold, setDrawerInnhold] = useState<DrawerInnhold | null>(null)
-    const [drawerPlassering, setDrawerPlassering] = useState<'bunn' | 'hoyre'>('bunn')
+    const [drawerPlassering, setDrawerPlassering] = useState<'bunn' | 'hoyre'>('hoyre')
+    const [sammenlignModus, setSammenlignModus] = useState(false)
+    const [sammenlignValgte, setSammenlignValgte] = useState<SammenlignElement[]>([])
 
     const gyldigeSykmeldinger = validerSykmeldingsDatoer(sykmeldinger)
     const filtrerteSykmeldinger = filtrerPaFilter(gyldigeSykmeldinger, filter)
@@ -99,6 +108,45 @@ export const useTidslinjeKombinert = (
         setDrawerInnhold(null)
     }, [])
 
+    const handleSammenlignValgt = useCallback((element: SammenlignElement) => {
+        setSammenlignValgte((gjeldende) => {
+            const erAlleredeValgt = gjeldende.some((e) => e.kildeId === element.kildeId)
+            if (erAlleredeValgt) {
+                return gjeldende.filter((e) => e.kildeId !== element.kildeId)
+            }
+            if (gjeldende.length >= 2) {
+                const nyListe = [gjeldende[1], element]
+                setDrawerInnhold(
+                    lagSammenlignDrawerInnhold(
+                        nyListe[0].objekt,
+                        nyListe[0].tittel,
+                        nyListe[1].objekt,
+                        nyListe[1].tittel,
+                    ),
+                )
+                return nyListe
+            }
+            const nyListe = [...gjeldende, element]
+            if (nyListe.length === 2) {
+                setDrawerInnhold(
+                    lagSammenlignDrawerInnhold(
+                        nyListe[0].objekt,
+                        nyListe[0].tittel,
+                        nyListe[1].objekt,
+                        nyListe[1].tittel,
+                    ),
+                )
+            }
+            return nyListe
+        })
+    }, [])
+
+    const handleAvsluttSammenlign = useCallback(() => {
+        setSammenlignModus(false)
+        setSammenlignValgte([])
+        setDrawerInnhold(null)
+    }, [])
+
     return {
         filter,
         setFilter,
@@ -118,5 +166,10 @@ export const useTidslinjeKombinert = (
         handlePeriodeValgt,
         handleDrawerValgt,
         handleLukkDrawer,
+        sammenlignModus,
+        setSammenlignModus,
+        sammenlignValgte,
+        handleSammenlignValgt,
+        handleAvsluttSammenlign,
     }
 }

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -27,6 +27,7 @@ export const useTidslinjeKombinert = (
     klipp: KlippetSykepengesoknadRecord[],
     eksternSammenlignModus?: boolean,
     onEksternSammenlignAvslutt?: () => void,
+    onSammenlignValgteEndret?: (titler: string[]) => void,
 ) => {
     const [filter, setFilter] = useState<Filter[]>([])
     const [visningsFraDato, setVisningsFraDato] = useState<Date | null>(null)
@@ -111,40 +112,46 @@ export const useTidslinjeKombinert = (
         setDrawerInnhold(null)
     }, [])
 
-    const handleSammenlignValgt = useCallback((element: SammenlignElement) => {
-        setSammenlignValgte((gjeldende) => {
-            const erAlleredeValgt = gjeldende.some((e) => e.kildeId === element.kildeId)
-            if (erAlleredeValgt) {
-                const nyListe = gjeldende.filter((e) => e.kildeId !== element.kildeId)
-                setDrawerInnhold(null)
+    const handleSammenlignValgt = useCallback(
+        (element: SammenlignElement) => {
+            setSammenlignValgte((gjeldende) => {
+                const erAlleredeValgt = gjeldende.some((e) => e.kildeId === element.kildeId)
+                if (erAlleredeValgt) {
+                    const nyListe = gjeldende.filter((e) => e.kildeId !== element.kildeId)
+                    setDrawerInnhold(null)
+                    onSammenlignValgteEndret?.(nyListe.map((e) => e.tittel))
+                    return nyListe
+                }
+                if (gjeldende.length >= 2) {
+                    const nyListe = [gjeldende[1], element]
+                    setDrawerInnhold(
+                        lagSammenlignDrawerInnhold(
+                            nyListe[0].objekt,
+                            nyListe[0].tittel,
+                            nyListe[1].objekt,
+                            nyListe[1].tittel,
+                        ),
+                    )
+                    onSammenlignValgteEndret?.(nyListe.map((e) => e.tittel))
+                    return nyListe
+                }
+                const nyListe = [...gjeldende, element]
+                if (nyListe.length === 2) {
+                    setDrawerInnhold(
+                        lagSammenlignDrawerInnhold(
+                            nyListe[0].objekt,
+                            nyListe[0].tittel,
+                            nyListe[1].objekt,
+                            nyListe[1].tittel,
+                        ),
+                    )
+                }
+                onSammenlignValgteEndret?.(nyListe.map((e) => e.tittel))
                 return nyListe
-            }
-            if (gjeldende.length >= 2) {
-                const nyListe = [gjeldende[1], element]
-                setDrawerInnhold(
-                    lagSammenlignDrawerInnhold(
-                        nyListe[0].objekt,
-                        nyListe[0].tittel,
-                        nyListe[1].objekt,
-                        nyListe[1].tittel,
-                    ),
-                )
-                return nyListe
-            }
-            const nyListe = [...gjeldende, element]
-            if (nyListe.length === 2) {
-                setDrawerInnhold(
-                    lagSammenlignDrawerInnhold(
-                        nyListe[0].objekt,
-                        nyListe[0].tittel,
-                        nyListe[1].objekt,
-                        nyListe[1].tittel,
-                    ),
-                )
-            }
-            return nyListe
-        })
-    }, [])
+            })
+        },
+        [onSammenlignValgteEndret],
+    )
 
     const handleAvsluttSammenlign = useCallback(() => {
         if (onEksternSammenlignAvslutt) {
@@ -154,7 +161,8 @@ export const useTidslinjeKombinert = (
         }
         setSammenlignValgte([])
         setDrawerInnhold(null)
-    }, [onEksternSammenlignAvslutt])
+        onSammenlignValgteEndret?.([])
+    }, [onEksternSammenlignAvslutt, onSammenlignValgteEndret])
 
     const handleStartSammenlign = useCallback(() => {
         setInternSammenlignModus(true)
@@ -163,8 +171,9 @@ export const useTidslinjeKombinert = (
     const handleLukkSammenlignDrawer = useCallback(() => {
         setSammenlignValgte([])
         setDrawerInnhold(null)
+        onSammenlignValgteEndret?.([])
         // sammenlignModus forblir true — brukeren kan velge nye elementer
-    }, [])
+    }, [onSammenlignValgteEndret])
 
     return {
         filter,

--- a/src/components/kombinert/useTidslinjeKombinert.ts
+++ b/src/components/kombinert/useTidslinjeKombinert.ts
@@ -112,7 +112,9 @@ export const useTidslinjeKombinert = (
         setSammenlignValgte((gjeldende) => {
             const erAlleredeValgt = gjeldende.some((e) => e.kildeId === element.kildeId)
             if (erAlleredeValgt) {
-                return gjeldende.filter((e) => e.kildeId !== element.kildeId)
+                const nyListe = gjeldende.filter((e) => e.kildeId !== element.kildeId)
+                setDrawerInnhold(null)
+                return nyListe
             }
             if (gjeldende.length >= 2) {
                 const nyListe = [gjeldende[1], element]

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Button, HStack } from '@navikt/ds-react'
+import { BodyShort, Button, HStack } from '@navikt/ds-react'
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons'
 
 import FnrSokefelt from '../components/FnrSokefelt'
@@ -10,15 +10,27 @@ import { useSykmeldinger } from '../queryhooks/useSykmeldinger'
 import TidslinjeKombinert from '../components/TidslinjeKombinert'
 import { useValgtFnr } from '../utils/useValgtFnr'
 
+const sammenlignStatusTekst = (titler: string[]) => {
+    if (titler.length === 0) return 'Velg første element'
+    if (titler.length === 1) return `Valgt: ${titler[0]} — velg ett til`
+    return `Sammenligner: ${titler[0]} vs ${titler[1]}`
+}
+
 const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
     const { fnr } = useValgtFnr()
     const [sammenlignModus, setSammenlignModus] = useState(false)
+    const [sammenlignTitler, setSammenlignTitler] = useState<string[]>([])
 
     const { data: soknadData } = useSoknader(fnr, fnr !== undefined)
     const soknader = soknadData?.sykepengesoknadListe || []
     const klipp = soknadData?.klippetSykepengesoknadRecord || []
 
     const { data: sykmeldinger = [] } = useSykmeldinger(fnr, fnr !== undefined)
+
+    const avsluttSammenlign = () => {
+        setSammenlignModus(false)
+        setSammenlignTitler([])
+    }
 
     return (
         <div className="space-y-4">
@@ -34,7 +46,6 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
                 </div>
                 {!sammenlignModus ? (
                     <Button
-                        size="small"
                         variant="secondary"
                         icon={<ArrowsSquarepathIcon aria-hidden />}
                         onClick={() => setSammenlignModus(true)}
@@ -42,9 +53,14 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
                         Sammenlign
                     </Button>
                 ) : (
-                    <Button size="small" variant="tertiary-neutral" onClick={() => setSammenlignModus(false)}>
-                        Avslutt sammenligning
-                    </Button>
+                    <HStack align="center" gap="space-3">
+                        <BodyShort className="text-ax-text-neutral-subtle italic" aria-live="polite" aria-atomic="true">
+                            {sammenlignStatusTekst(sammenlignTitler)}
+                        </BodyShort>
+                        <Button variant="tertiary-neutral" onClick={avsluttSammenlign}>
+                            Avslutt sammenligning
+                        </Button>
+                    </HStack>
                 )}
             </HStack>
             <TidslinjeKombinert
@@ -52,7 +68,8 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
                 soknader={soknader}
                 klipp={klipp}
                 sammenlignModus={sammenlignModus}
-                onSammenlignAvslutt={() => setSammenlignModus(false)}
+                onSammenlignAvslutt={avsluttSammenlign}
+                onSammenlignValgteEndret={setSammenlignTitler}
             />
         </div>
     )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,7 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
                         variant="secondary"
                         icon={<ArrowsSquarepathIcon aria-hidden />}
                         onClick={() => setSammenlignModus(true)}
+                        disabled={sykmeldinger.length === 0 && soknader.length === 0}
                     >
                         Sammenlign
                     </Button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,7 +54,7 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
                         Sammenlign
                     </Button>
                 ) : (
-                    <HStack align="center" gap="space-3">
+                    <HStack align="center" gap="space-4">
                         <BodyShort className="text-ax-text-neutral-subtle italic" aria-live="polite" aria-atomic="true">
                             {sammenlignStatusTekst(sammenlignTitler)}
                         </BodyShort>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Button, HStack } from '@navikt/ds-react'
+import { ArrowsSquarepathIcon } from '@navikt/aksel-icons'
 
 import FnrSokefelt from '../components/FnrSokefelt'
 import IdOppslagSokefelt from '../components/IdOppslagSokefelt'
@@ -10,6 +12,7 @@ import { useValgtFnr } from '../utils/useValgtFnr'
 
 const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
     const { fnr } = useValgtFnr()
+    const [sammenlignModus, setSammenlignModus] = useState(false)
 
     const { data: soknadData } = useSoknader(fnr, fnr !== undefined)
     const soknader = soknadData?.sykepengesoknadListe || []
@@ -19,16 +22,38 @@ const Index = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
 
     return (
         <div className="space-y-4">
-            <div className="inline-flex items-start gap-4">
-                <FnrSokefelt
-                    label="Fødselsnummer eller aktørId"
-                    description="11-sifret fnr eller 13-sifret aktørId"
-                    valideringstype="fnrEllerAktorId"
-                    erMockBackend={erMockBackend}
-                />
-                <IdOppslagSokefelt />
-            </div>
-            <TidslinjeKombinert sykmeldinger={sykmeldinger} soknader={soknader} klipp={klipp} />
+            <HStack align="end" gap="space-4" wrap={false}>
+                <div className="inline-flex items-start gap-4">
+                    <FnrSokefelt
+                        label="Fødselsnummer eller aktørId"
+                        description="11-sifret fnr eller 13-sifret aktørId"
+                        valideringstype="fnrEllerAktorId"
+                        erMockBackend={erMockBackend}
+                    />
+                    <IdOppslagSokefelt />
+                </div>
+                {!sammenlignModus ? (
+                    <Button
+                        size="small"
+                        variant="secondary"
+                        icon={<ArrowsSquarepathIcon aria-hidden />}
+                        onClick={() => setSammenlignModus(true)}
+                    >
+                        Sammenlign
+                    </Button>
+                ) : (
+                    <Button size="small" variant="tertiary-neutral" onClick={() => setSammenlignModus(false)}>
+                        Avslutt sammenligning
+                    </Button>
+                )}
+            </HStack>
+            <TidslinjeKombinert
+                sykmeldinger={sykmeldinger}
+                soknader={soknader}
+                klipp={klipp}
+                sammenlignModus={sammenlignModus}
+                onSammenlignAvslutt={() => setSammenlignModus(false)}
+            />
         </div>
     )
 }

--- a/src/utils/gruppering.test.ts
+++ b/src/utils/gruppering.test.ts
@@ -64,7 +64,7 @@ describe('gruppertOgFiltrert', () => {
         expect(nøkler.some((nøkkel) => nøkkel.startsWith('arbeidsgiver_GHOST'))).toBe(true)
     })
 
-    it('viser manuelt korrigert søknad normalt uten klipte blokker', () => {
+    it('viser manuelt korrigert søknad normalt og beholder klippehistorikk', () => {
         // Søknaden eksisterer i listen (manuelt gjenopprettet), men KlippetRecord har periodeEtter=null
         const gjenopprettetSoknad = lagSoknad({
             id: 'soknad-korrigert',
@@ -91,11 +91,13 @@ describe('gruppertOgFiltrert', () => {
         expect(nøkler).toContain('999999999')
         expect(nøkler.some((n) => n.endsWith('_GHOST'))).toBe(false)
 
-        // Søknaden skal ikke ha klipte perioder (ingen misvisende nøytrale blokker)
+        // Søknaden skal finnes i grupperingen
         const arbeidsgiver = gruppert.get('999999999')!
         const soknader = Array.from(arbeidsgiver.sykmeldinger.values()).flatMap((s) => Array.from(s.soknader.values()))
         expect(soknader).toHaveLength(1)
-        expect(soknader[0].klippingAvSoknad).toHaveLength(0)
+
+        // Klippehistorikken skal vises (historisk sporbarhet)
+        expect(soknader[0].klippingAvSoknad.length).toBeGreaterThan(0)
     })
 })
 

--- a/src/utils/gruppering.test.ts
+++ b/src/utils/gruppering.test.ts
@@ -63,6 +63,40 @@ describe('gruppertOgFiltrert', () => {
         expect(nøkler.some((nøkkel) => nøkkel.startsWith('naeringsdrivende'))).toBe(false)
         expect(nøkler.some((nøkkel) => nøkkel.startsWith('arbeidsgiver_GHOST'))).toBe(true)
     })
+
+    it('viser manuelt korrigert søknad normalt uten klipte blokker', () => {
+        // Søknaden eksisterer i listen (manuelt gjenopprettet), men KlippetRecord har periodeEtter=null
+        const gjenopprettetSoknad = lagSoknad({
+            id: 'soknad-korrigert',
+            sykmeldingId: 'sykmelding-korrigert',
+            arbeidssituasjon: 'ARBEIDSTAKER',
+            arbeidsgiverOrgnummer: '999999999',
+            fom: '2026-02-01',
+            tom: '2026-02-10',
+            soknadPerioder: [
+                { fom: '2026-02-01', tom: '2026-02-10', grad: 100, sykmeldingstype: 'AKTIVITET_IKKE_MULIG' },
+            ],
+        })
+        const klippForSammeUuid = lagKlipp({
+            sykepengesoknadUuid: 'soknad-korrigert',
+            sykmeldingUuid: 'sykmelding-korrigert',
+            periodeFor: [{ fom: '2026-02-01', tom: '2026-02-10', grad: 100, sykmeldingstype: 'AKTIVITET_IKKE_MULIG' }],
+            periodeEtter: null,
+        })
+
+        const gruppert = gruppertOgFiltrert([], [gjenopprettetSoknad], [klippForSammeUuid])
+
+        // Søknaden skal vises under riktig arbeidsgiver, ikke som ghost
+        const nøkler = Array.from(gruppert.keys())
+        expect(nøkler).toContain('999999999')
+        expect(nøkler.some((n) => n.endsWith('_GHOST'))).toBe(false)
+
+        // Søknaden skal ikke ha klipte perioder (ingen misvisende nøytrale blokker)
+        const arbeidsgiver = gruppert.get('999999999')!
+        const soknader = Array.from(arbeidsgiver.sykmeldinger.values()).flatMap((s) => Array.from(s.soknader.values()))
+        expect(soknader).toHaveLength(1)
+        expect(soknader[0].klippingAvSoknad).toHaveLength(0)
+    })
 })
 
 describe('sortert', () => {

--- a/src/utils/gruppering.ts
+++ b/src/utils/gruppering.ts
@@ -84,9 +84,9 @@ function grupperPaSykmelding(
             sykmeldingGruppering.forEach((sykmelding) => {
                 // TODO: Vi finner aldri denne søknaden, og vi kjenner heller ikke sykmelding id'n, så i disse tilfellene klarer vi ikke koble sammen klipping av søknad med riktig sykmelding
                 if (sykmelding.soknader.has(k.sykepengesoknadUuid)) {
-                    // Søknaden finnes i systemet selv om klipperecorden sier den ble fullstendig fjernet.
-                    // Dette skjer når søknaden er manuelt korrigert/gjenopprettet etter klippingen.
-                    // Vi legger ikke til gammel klippeinfo – søknaden skal vises normalt.
+                    // Søknaden finnes i systemet (manuelt gjenopprettet etter klipping).
+                    // Vi beholder klippehistorikken for full sporbarhet, men søknaden vises også normalt.
+                    sykmelding.soknader.get(k.sykepengesoknadUuid)?.klippingAvSoknad.push(...perioderSomErKlippet)
                     sykmeldingEksisterte = true
                 }
             })

--- a/src/utils/gruppering.ts
+++ b/src/utils/gruppering.ts
@@ -84,7 +84,9 @@ function grupperPaSykmelding(
             sykmeldingGruppering.forEach((sykmelding) => {
                 // TODO: Vi finner aldri denne søknaden, og vi kjenner heller ikke sykmelding id'n, så i disse tilfellene klarer vi ikke koble sammen klipping av søknad med riktig sykmelding
                 if (sykmelding.soknader.has(k.sykepengesoknadUuid)) {
-                    sykmelding.soknader.get(k.sykepengesoknadUuid)?.klippingAvSoknad.push(...perioderSomErKlippet)
+                    // Søknaden finnes i systemet selv om klipperecorden sier den ble fullstendig fjernet.
+                    // Dette skjer når søknaden er manuelt korrigert/gjenopprettet etter klippingen.
+                    // Vi legger ikke til gammel klippeinfo – søknaden skal vises normalt.
                     sykmeldingEksisterte = true
                 }
             })

--- a/src/utils/sammenlignUtils.test.ts
+++ b/src/utils/sammenlignUtils.test.ts
@@ -85,10 +85,7 @@ describe('sammenlignObjekter', () => {
     })
 
     it('sammenligner nestede objekt-felt', () => {
-        const rader = sammenlignObjekter(
-            { arbeidsgiver: { navn: 'NAV' } },
-            { arbeidsgiver: { navn: 'NHO' } },
-        )
+        const rader = sammenlignObjekter({ arbeidsgiver: { navn: 'NAV' } }, { arbeidsgiver: { navn: 'NHO' } })
         const rad = rader.find((r) => r.nøkkel === 'arbeidsgiver.navn')
         expect(rad).toMatchObject({ verdi1: 'NAV', verdi2: 'NHO', erLik: false })
     })

--- a/src/utils/sammenlignUtils.test.ts
+++ b/src/utils/sammenlignUtils.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import dayjs from 'dayjs'
+
+import { flatUtObjekt, sammenlignObjekter } from './sammenlignUtils'
+
+describe('flatUtObjekt', () => {
+    it('flater ut flate objekt', () => {
+        const resultat = flatUtObjekt({ navn: 'Ole', alder: 30 })
+        expect(resultat).toEqual({ navn: 'Ole', alder: '30' })
+    })
+
+    it('flater ut nestet objekt med dot-notation', () => {
+        const resultat = flatUtObjekt({ arbeidsgiver: { navn: 'NAV', orgnr: '123' } })
+        expect(resultat).toEqual({ 'arbeidsgiver.navn': 'NAV', 'arbeidsgiver.orgnr': '123' })
+    })
+
+    it('håndterer tomt objekt som verdi', () => {
+        const resultat = flatUtObjekt({ a: {} })
+        expect(resultat).toEqual({ a: '{}' })
+    })
+
+    it('håndterer tom array', () => {
+        const resultat = flatUtObjekt({ perioder: [] })
+        expect(resultat).toEqual({ perioder: '[]' })
+    })
+
+    it('håndterer array med verdier', () => {
+        const resultat = flatUtObjekt({ perioder: ['2024-01-01', '2024-02-01'] })
+        expect(resultat['perioder[0]']).toMatch(/1.*Jan.*2024/i)
+        expect(resultat['perioder[1]']).toMatch(/1.*Feb.*2024/i)
+    })
+
+    it('formaterer datostreng', () => {
+        const resultat = flatUtObjekt({ fom: '2024-01-15' })
+        expect(resultat['fom']).toMatch(/15.*Jan.*2024/i)
+    })
+
+    it('formaterer dayjs-objekt', () => {
+        const resultat = flatUtObjekt({ fom: dayjs('2024-03-20') })
+        expect(resultat['fom']).toMatch(/20.*Mar.*2024/i)
+    })
+
+    it('håndterer null-verdier', () => {
+        const resultat = flatUtObjekt({ felt: null })
+        expect(resultat).toEqual({ felt: 'null' })
+    })
+
+    it('håndterer boolean-verdier', () => {
+        const resultat = flatUtObjekt({ aktiv: true, slettet: false })
+        expect(resultat).toEqual({ aktiv: 'true', slettet: 'false' })
+    })
+})
+
+describe('sammenlignObjekter', () => {
+    it('returnerer lik=true for identiske felt', () => {
+        const rader = sammenlignObjekter({ status: 'SENDT' }, { status: 'SENDT' })
+        expect(rader).toHaveLength(1)
+        expect(rader[0]).toMatchObject({ nøkkel: 'status', verdi1: 'SENDT', verdi2: 'SENDT', erLik: true })
+    })
+
+    it('returnerer lik=false for forskjellige felt', () => {
+        const rader = sammenlignObjekter({ status: 'SENDT' }, { status: 'AVBRUTT' })
+        expect(rader[0]).toMatchObject({ nøkkel: 'status', verdi1: 'SENDT', verdi2: 'AVBRUTT', erLik: false })
+    })
+
+    it('viser felt som mangler i det ene objektet', () => {
+        const rader = sammenlignObjekter({ a: '1', b: '2' }, { a: '1' })
+        const radB = rader.find((r) => r.nøkkel === 'b')
+        expect(radB).toMatchObject({ verdi1: '2', verdi2: undefined, erLik: false })
+    })
+
+    it('håndterer tomt objekt som verdi', () => {
+        const rader = sammenlignObjekter({ arsak: {} }, { arsak: null })
+        const rad = rader.find((r) => r.nøkkel === 'arsak')
+        expect(rad).toBeDefined()
+        expect(rad!.erLik).toBe(false)
+        expect(rad!.verdi1).toBe('{}')
+        expect(rad!.verdi2).toBe('null')
+    })
+
+    it('sorterer nøklene alfabetisk', () => {
+        const rader = sammenlignObjekter({ z: '1', a: '2' }, { z: '1', a: '2' })
+        expect(rader[0].nøkkel).toBe('a')
+        expect(rader[1].nøkkel).toBe('z')
+    })
+
+    it('sammenligner nestede objekt-felt', () => {
+        const rader = sammenlignObjekter(
+            { arbeidsgiver: { navn: 'NAV' } },
+            { arbeidsgiver: { navn: 'NHO' } },
+        )
+        const rad = rader.find((r) => r.nøkkel === 'arbeidsgiver.navn')
+        expect(rad).toMatchObject({ verdi1: 'NAV', verdi2: 'NHO', erLik: false })
+    })
+})

--- a/src/utils/sammenlignUtils.ts
+++ b/src/utils/sammenlignUtils.ts
@@ -1,0 +1,86 @@
+import dayjs, { Dayjs } from 'dayjs'
+
+const erObjekt = (verdi: unknown): verdi is Record<string, unknown> =>
+    typeof verdi === 'object' && verdi !== null && !Array.isArray(verdi)
+
+const erDayjsObjekt = (verdi: unknown): verdi is Dayjs => dayjs.isDayjs(verdi)
+
+const erDatostreng = (verdi: string): boolean => {
+    if (!/^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})?)?$/.test(verdi)) {
+        return false
+    }
+    return dayjs(verdi).isValid()
+}
+
+const harTidspunkt = (verdi: string): boolean => /[T ]\d{2}:\d{2}/.test(verdi)
+
+export const formaterVerdiSammenlign = (verdi: unknown): string => {
+    if (erDayjsObjekt(verdi)) return verdi.format('D MMM YYYY HH:mm')
+    if (typeof verdi === 'string') {
+        if (erDatostreng(verdi)) {
+            const dato = dayjs(verdi)
+            return dato.format(harTidspunkt(verdi) ? 'D MMM YYYY HH:mm' : 'D MMM YYYY')
+        }
+        return verdi
+    }
+    if (verdi === null) return 'null'
+    if (verdi === undefined) return 'undefined'
+    if (typeof verdi === 'boolean') return verdi ? 'true' : 'false'
+    if (typeof verdi === 'number') return String(verdi)
+    return JSON.stringify(verdi)
+}
+
+export const flatUtObjekt = (obj: unknown, prefix = ''): Record<string, string> => {
+    const resultat: Record<string, string> = {}
+
+    if (Array.isArray(obj)) {
+        if (obj.length === 0) {
+            resultat[prefix] = '[]'
+        } else {
+            obj.forEach((element, indeks) => {
+                const nøkkel = prefix ? `${prefix}[${indeks}]` : `[${indeks}]`
+                const nested = flatUtObjekt(element, nøkkel)
+                Object.assign(resultat, nested)
+            })
+        }
+    } else if (erDayjsObjekt(obj)) {
+        resultat[prefix] = formaterVerdiSammenlign(obj)
+    } else if (erObjekt(obj)) {
+        for (const [nøkkel, verdi] of Object.entries(obj)) {
+            const sti = prefix ? `${prefix}.${nøkkel}` : nøkkel
+            const nested = flatUtObjekt(verdi, sti)
+            Object.assign(resultat, nested)
+        }
+    } else {
+        resultat[prefix] = formaterVerdiSammenlign(obj)
+    }
+
+    return resultat
+}
+
+export interface SammenlignRad {
+    nøkkel: string
+    verdi1: string | undefined
+    verdi2: string | undefined
+    erLik: boolean
+}
+
+export const sammenlignObjekter = (obj1: object, obj2: object): SammenlignRad[] => {
+    const flat1 = flatUtObjekt(obj1)
+    const flat2 = flatUtObjekt(obj2)
+
+    const alleNøkler = new Set([...Object.keys(flat1), ...Object.keys(flat2)])
+
+    return Array.from(alleNøkler)
+        .sort()
+        .map((nøkkel) => {
+            const verdi1 = flat1[nøkkel]
+            const verdi2 = flat2[nøkkel]
+            return {
+                nøkkel,
+                verdi1,
+                verdi2,
+                erLik: verdi1 === verdi2,
+            }
+        })
+}

--- a/src/utils/sammenlignUtils.ts
+++ b/src/utils/sammenlignUtils.ts
@@ -46,10 +46,15 @@ export const flatUtObjekt = (obj: unknown, prefix = ''): Record<string, string> 
     } else if (erDayjsObjekt(obj)) {
         resultat[prefix] = formaterVerdiSammenlign(obj)
     } else if (erObjekt(obj)) {
-        for (const [nøkkel, verdi] of Object.entries(obj)) {
-            const sti = prefix ? `${prefix}.${nøkkel}` : nøkkel
-            const nested = flatUtObjekt(verdi, sti)
-            Object.assign(resultat, nested)
+        const entries = Object.entries(obj)
+        if (entries.length === 0) {
+            if (prefix) resultat[prefix] = '{}'
+        } else {
+            for (const [nøkkel, verdi] of entries) {
+                const sti = prefix ? `${prefix}.${nøkkel}` : nøkkel
+                const nested = flatUtObjekt(verdi, sti)
+                Object.assign(resultat, nested)
+            }
         }
     } else {
         resultat[prefix] = formaterVerdiSammenlign(obj)


### PR DESCRIPTION
- **Legg til sammenligning av to søknader eller sykmeldinger i tidslinjen**
- **Fikse valgfrie sammenlign-props og stale drawer ved deselection**
- **Fikse tomme objekter i sammenlign, legg til aria-live og tester**
- **Fiks review-funn: Aksel v8-tokens, ToggleGroup API, aria-live, datoformat og lukkehåndtering**
- **Formatter sammenlignUtils.test.ts**
- **Flytt Sammenlign-knapp ved siden av søkefeltene**
- **Vis statustekst ved sammenlign-knappen og gjør knappen større**
- **Fjern duplikat statustekst og deaktiver sammenlign-knapp uten data**
- **Fiks ugyldig Aksel space-token: space-3 → space-4**
- **Vis manuelt korrigerte klippede søknader i tidslinjen**
