### PR TITLE
Oppdater visning av forelagte opplysninger

### DIFF
--- a/src/components/TidslinjeVedtaksperioder.tsx
+++ b/src/components/TidslinjeVedtaksperioder.tsx
@@ -186,18 +186,18 @@ export function TidslinjeVedtaksperioder({
                                                         brukervarselId: null,
                                                         dittSykefravaerMeldingId: null,
                                                         opprettetDatabase: forelagt.opprettet,
-                                                        status: 'FORELEGGING_FORESPORSEL_MOTTATT',
+                                                        status: 'NY',
                                                         tidspunkt: forelagt.opprinneligOpprettet,
                                                         vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                     })
 
-                                                    if (forelagt.status === 'SENDT' && forelagt.statusEndret) {
+                                                    if (forelagt.statusEndret && forelagt.status !== 'NY') {
                                                         statuserMedForelegging.push({
                                                             id: forelagt.id,
                                                             brukervarselId: null,
                                                             dittSykefravaerMeldingId: null,
                                                             opprettetDatabase: forelagt.opprettet,
-                                                            status: 'FORELEGGING_VARSEL_SENDT',
+                                                            status: forelagt.status,
                                                             tidspunkt: forelagt.statusEndret,
                                                             vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                         })

--- a/src/components/TidslinjeVedtaksperioder.tsx
+++ b/src/components/TidslinjeVedtaksperioder.tsx
@@ -186,7 +186,7 @@ export function TidslinjeVedtaksperioder({
                                                         brukervarselId: null,
                                                         dittSykefravaerMeldingId: null,
                                                         opprettetDatabase: forelagt.opprettet,
-                                                        status: 'NY',
+                                                        status: `FORELAGTE_OPPLYSNINGER_NY`,
                                                         tidspunkt: forelagt.opprinneligOpprettet,
                                                         vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                     })
@@ -197,7 +197,7 @@ export function TidslinjeVedtaksperioder({
                                                             brukervarselId: null,
                                                             dittSykefravaerMeldingId: null,
                                                             opprettetDatabase: forelagt.opprettet,
-                                                            status: forelagt.status,
+                                                            status: `FORELAGTE_OPPLYSNINGER_${forelagt.status}`,
                                                             tidspunkt: forelagt.statusEndret,
                                                             vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                         })

--- a/src/components/TidslinjeVedtaksperioder.tsx
+++ b/src/components/TidslinjeVedtaksperioder.tsx
@@ -30,8 +30,8 @@ export function TidslinjeVedtaksperioder({
         })
     })
     forelagteOpplysninger.forEach((fo) => {
-        if (fo.forelagt != null) {
-            datoer.push(dayjs(fo.forelagt))
+        if (fo.statusEndret != null) {
+            datoer.push(dayjs(fo.statusEndret))
         }
         datoer.push(dayjs(fo.opprettet))
         datoer.push(dayjs(fo.opprinneligOpprettet))
@@ -104,13 +104,28 @@ export function TidslinjeVedtaksperioder({
                     )
                 })}
                 {forelagteOpplysninger.map((fo) => {
-                    if (fo.forelagt == null) {
-                        return null
-                    }
+                    const pinDato = fo.status === 'SENDT' ? fo.statusEndret : fo.opprinneligOpprettet
+                    if (!pinDato) return null
                     return (
-                        <Timeline.Pin key={fo.id} date={dayjs(fo.forelagt).toDate()}>
+                        <Timeline.Pin key={fo.id} date={dayjs(pinDato).toDate()}>
                             <p>Forelagt opplysninger fra A-Ordningen</p>
-                            <p>{formatterTimestamp(fo.forelagt)}</p>
+                            <p>Status: {fo.status}</p>
+                            <p>{formatterTimestamp(pinDato)}</p>
+                            {fo.forelagteOpplysningerMelding && (
+                                <ReadMore header="Inntektsdata">
+                                    <p>
+                                        Omregnet årsinntekt:{' '}
+                                        {fo.forelagteOpplysningerMelding.omregnetÅrsinntekt.toLocaleString('nb-NO')} kr
+                                    </p>
+                                    <ul>
+                                        {fo.forelagteOpplysningerMelding.skatteinntekter.map((si) => (
+                                            <li key={si.måned}>
+                                                {si.måned}: {si.beløp.toLocaleString('nb-NO')} kr
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </ReadMore>
+                            )}
                         </Timeline.Pin>
                     )
                 })}
@@ -157,7 +172,11 @@ export function TidslinjeVedtaksperioder({
                                                 Behandlinger
                                             </BodyShort>
                                             {sortertEtterOppdatert.map((behandling) => {
-                                                const statuserMedForelegging = [...behandling.statuser]
+                                                const statuserMedForelegging: Array<
+                                                    Omit<VedtaksperiodeBehandlingStatusDbRecord, 'status'> & {
+                                                        status: string
+                                                    }
+                                                > = [...behandling.statuser]
                                                 const forelagt = forelagteMap.get(
                                                     `${behandling.vedtaksperiode.vedtaksperiodeId}-${behandling.vedtaksperiode.behandlingId}`,
                                                 )
@@ -172,14 +191,14 @@ export function TidslinjeVedtaksperioder({
                                                         vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                     })
 
-                                                    if (forelagt.forelagt) {
+                                                    if (forelagt.status === 'SENDT' && forelagt.statusEndret) {
                                                         statuserMedForelegging.push({
                                                             id: forelagt.id,
                                                             brukervarselId: null,
                                                             dittSykefravaerMeldingId: null,
                                                             opprettetDatabase: forelagt.opprettet,
                                                             status: 'FORELEGGING_VARSEL_SENDT',
-                                                            tidspunkt: forelagt.forelagt,
+                                                            tidspunkt: forelagt.statusEndret,
                                                             vedtaksperiodeBehandlingId: behandling.vedtaksperiode.id!,
                                                         })
                                                     }
@@ -188,7 +207,7 @@ export function TidslinjeVedtaksperioder({
                                                     a.tidspunkt.localeCompare(b.tidspunkt),
                                                 )
 
-                                                const tidligstePerStatus: VedtaksperiodeBehandlingStatusDbRecord[] = []
+                                                const tidligstePerStatus: typeof statuserMedForelegging = []
                                                 let forrigeStatus: string | undefined = undefined
 
                                                 for (const element of sortert) {

--- a/src/pages/vedtaksperioder.tsx
+++ b/src/pages/vedtaksperioder.tsx
@@ -3,7 +3,7 @@ import { Alert, BodyShort, Button, Link, Radio, RadioGroup, ReadMore, Search } f
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 
-import { initialProps } from '../initialprops/initialProps'
+import { initialProps, PrefetchResults } from '../initialprops/initialProps'
 import {
     FullVedtaksperiodeBehandling,
     useVedtaksperioderMedInntektsmeldinger,
@@ -88,7 +88,7 @@ const FnrVisning = ({
     )
 }
 
-const Vedtaksperioder = () => {
+const Vedtaksperioder = ({ erMockBackend }: Pick<PrefetchResults, 'erMockBackend'>) => {
     const { fnr, nullstillFnr } = useValgtFnr()
     const [vedtaksperiodeId, setVedtaksperiodeId] = useState<string>()
     const [sokeinput, setSokeinput] = useState<'vedtaksperiodeid' | 'fnr'>('vedtaksperiodeid')
@@ -133,7 +133,7 @@ const Vedtaksperioder = () => {
                 <Radio value="vedtaksperiodeid">VedtaksperiodeId</Radio>
                 <Radio value="fnr">Fødselsnummer</Radio>
             </RadioGroup>
-            {sokeinput === 'fnr' && <FnrSokefelt />}
+            {sokeinput === 'fnr' && <FnrSokefelt erMockBackend={erMockBackend} />}
             {sokeinput === 'vedtaksperiodeid' && (
                 <Search
                     className="w-80"

--- a/src/queryhooks/useVedtaksperioderMedInntektsmeldinger.ts
+++ b/src/queryhooks/useVedtaksperioderMedInntektsmeldinger.ts
@@ -100,7 +100,6 @@ type StatusVerdi =
     | 'VARSLET_MANGLER_INNTEKTSMELDING_28_DONE'
     | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_28'
     | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_28_DONE'
-    | 'SENDT_SMSER'
 
 export interface InntektsmeldingDbRecord {
     id: string | null

--- a/src/queryhooks/useVedtaksperioderMedInntektsmeldinger.ts
+++ b/src/queryhooks/useVedtaksperioderMedInntektsmeldinger.ts
@@ -74,7 +74,33 @@ export interface VedtaksperiodeBehandlingStatusDbRecord {
     dittSykefravaerMeldingId: string | null
 }
 
-type StatusVerdi = string
+type StatusVerdi =
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_FØRSTE'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_FØRSTE_DONE'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_ANDRE'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_ANDRE_DONE'
+    | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_FØRSTE'
+    | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_FØRSTE_DONE'
+    | 'OPPRETTET'
+    | 'VENTER_PÅ_ARBEIDSGIVER'
+    | 'VENTER_PÅ_SAKSBEHANDLER'
+    | 'VENTER_PÅ_ANNEN_PERIODE'
+    | 'FERDIG'
+    | 'BEHANDLES_UTENFOR_SPEIL'
+    | 'REVARSLET_VENTER_PÅ_SAKSBEHANDLER'
+    | 'REVARSLET_VENTER_PÅ_SAKSBEHANDLER_DONE'
+    | 'VARSLER_IKKE_GRUNNET_FULL_REFUSJON'
+    | 'VARSLET_FORSINKET_PA_ANNEN_ORGNUMMER'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_DONE'
+    | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_15'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_15_DONE'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_28'
+    | 'VARSLET_MANGLER_INNTEKTSMELDING_28_DONE'
+    | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_28'
+    | 'VARSLET_VENTER_PÅ_SAKSBEHANDLER_28_DONE'
+    | 'SENDT_SMSER'
 
 export interface InntektsmeldingDbRecord {
     id: string | null
@@ -93,7 +119,24 @@ export interface ForelagteOpplysningerDbRecord {
     id: string | null
     vedtaksperiodeId: string
     behandlingId: string
+    forelagteOpplysningerMelding: ForelagteOpplysningerMelding | null
     opprettet: string
     opprinneligOpprettet: string
-    forelagt: string | null
+    status: ForelagtStatus
+    statusEndret: string | null
+}
+
+export type ForelagtStatus = 'NY' | 'SENDT' | 'AVBRUTT'
+
+export interface ForelagteOpplysningerMelding {
+    vedtaksperiodeId: string
+    behandlingId: string
+    tidsstempel: string
+    omregnetÅrsinntekt: number
+    skatteinntekter: Skatteinntekt[]
+}
+
+interface Skatteinntekt {
+    måned: string
+    beløp: number
 }

--- a/src/testdata/testdata.ts
+++ b/src/testdata/testdata.ts
@@ -21,7 +21,7 @@ const vedtaksperiodeTestdata: FullVedtaksperiodeBehandling[] = [
             opprettetDatabase: '2024-05-13T10:56:50.855626Z',
             oppdatert: '2024-05-13T10:56:50.883256Z',
             sisteSpleisstatus: 'VENTER_PÅ_ARBEIDSGIVER',
-            sisteVarslingstatus: 'SENDT_SMSER',
+            sisteVarslingstatus: 'VARSLET_MANGLER_INNTEKTSMELDING_FØRSTE',
             vedtaksperiodeId: '3337dceb-e5a5-481d-b659-b55da88a6d61',
             behandlingId: '5809d055-3ccf-49d9-aee7-d81e88db25ee',
             sykepengesoknadUuid: '2f7a41d4-1658-4049-9694-94d1df7fcd6f',

--- a/src/testdata/testdata.ts
+++ b/src/testdata/testdata.ts
@@ -4,6 +4,7 @@ import { Stream } from 'node:stream'
 import { NextApiRequest } from 'next'
 
 import {
+    ForelagteOpplysningerDbRecord,
     FullVedtaksperiodeBehandling,
     InntektsmeldingDbRecord,
 } from '../queryhooks/useVedtaksperioderMedInntektsmeldinger'
@@ -324,11 +325,36 @@ export async function mockApi(opts: BackendProxyOpts): Promise<void> {
             foersteFravaersdag: '2024-04-26',
             vedtaksperiodeId: '123',
         }
+        const forelagteOpplysninger: ForelagteOpplysningerDbRecord[] = [
+            {
+                id: 'fo-test-001',
+                vedtaksperiodeId: '3337dceb-e5a5-481d-b659-b55da88a6d61',
+                behandlingId: '5809d055-3ccf-49d9-aee7-d81e88db25ee',
+                forelagteOpplysningerMelding: {
+                    vedtaksperiodeId: '3337dceb-e5a5-481d-b659-b55da88a6d61',
+                    behandlingId: '5809d055-3ccf-49d9-aee7-d81e88db25ee',
+                    tidsstempel: '2024-06-20T08:00:00',
+                    omregnetÅrsinntekt: 624000,
+                    skatteinntekter: [
+                        { måned: '2024-01', beløp: 52000 },
+                        { måned: '2024-02', beløp: 52000 },
+                        { måned: '2024-03', beløp: 52000 },
+                        { måned: '2024-04', beløp: 52000 },
+                        { måned: '2024-05', beløp: 52000 },
+                        { måned: '2024-06', beløp: 52000 },
+                    ],
+                },
+                opprettet: '2024-06-20T08:00:00Z',
+                opprinneligOpprettet: '2024-06-19T12:00:00Z',
+                status: 'SENDT',
+                statusEndret: '2024-06-25T10:30:00Z',
+            },
+        ]
         res.status(200)
         res.json({
             inntektsmeldinger: [inntektsmedling],
             vedtaksperioder: vedtaksperiodeTestdata,
-            forelagteOpplysninger: [],
+            forelagteOpplysninger,
         })
         res.end()
         return


### PR DESCRIPTION
## Endringer

### Datamodell
- Bytt ut `forelagt: string | null` med `status: 'NY' | 'SENDT' | 'AVBRUTT'`, `statusEndret` og `forelagteOpplysningerMelding`
- Ny interface `ForelagteOpplysningerMelding` med `omregnetÅrsinntekt` og `skatteinntekter`

### StatusVerdi
- Utvidet fra `type StatusVerdi = string` til fullstendig union type som matcher backend-enum
- Fjernet legacy `SENDT_SMSER`

### Tidslinje
- `Timeline.Pin` viser nå status og inntektsdata (ReadMore) for alle statuser, ikke bare SENDT
- Forelagte opplysninger vises i statuslisten som `FORELAGTE_OPPLYSNINGER_NY` / `FORELAGTE_OPPLYSNINGER_SENDT` / `FORELAGTE_OPPLYSNINGER_AVBRUTT` for å skille dem tydelig fra vedtaksperiode-statuser

### Lokalt/testdata
- Testdata inneholder nå et eksempel på forelagte opplysninger med inntektsdata
- FNR-søk støtter tom input lokalt (som de andre sidene)